### PR TITLE
Add yearly_mmap feature-store backends; remove horizons; fix mmap build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@ logs/*
 .snakemake/*
 slurm*
 .hydra/*
-*/__pycache__/*
+**/__pycache__/
 env/*
 *.egg-info
 *.log
 .vscode/*
+build_logs/
+scratch/

--- a/benchmarking/benchmark.py
+++ b/benchmarking/benchmark.py
@@ -1,0 +1,383 @@
+"""Main benchmarking script for HealthXDataset.
+
+Two modes, selected by ``mode`` (formats | scaling | all):
+
+  formats   For each on-disk format (daily_parquet, yearly_mmap_dense,
+            yearly_mmap_sparse) time `n_samples` random ``__getitem__`` reads
+            and record read latency, RSS, and on-disk size.
+  scaling   On yearly_mmap_dense, sweep (num_workers, batch_size, prefetch) and
+            measure DataLoader throughput over `n_batches` batches per cell.
+
+Everything is driven by Hydra (``conf/benchmark.yaml``). The ``var_dict`` is a
+shared config group (``conf/var_dict/``) mirroring the climhealth workload, so
+the same file feeds the loaders and this benchmark. Override on the CLI, e.g.
+
+    python benchmarking/benchmark.py var_dict=lego_small mode=formats
+    python benchmarking/benchmark.py n_samples=100 batch_sizes=[32,64] n_batches=15
+
+Build the formats first via
+    snakemake -s snakefile.smk         --cores N --config format=<fmt>
+    snakemake -s snakefile_health.smk  --cores N --config format=<fmt>
+"""
+from __future__ import annotations
+import gc, json, socket, sys, time
+from pathlib import Path
+
+
+import hydra
+import numpy as np
+import psutil
+import torch
+from omegaconf import DictConfig, OmegaConf
+from torch.utils.data import DataLoader
+
+from legoloaderx import HealthXDataset
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RESULTS_DIR = REPO_ROOT / "benchmarking" / "results"
+PLOTS_DIR = REPO_ROOT / "benchmarking" / "plots"
+
+ROLES = ("outcomes", "treatments", "confounders")
+FORMATS = ["daily_parquet", "yearly_mmap_dense", "yearly_mmap_sparse"]
+
+
+def build_var_dict(cfg):
+    """Extract the three HealthXDataset roles from the shared var_dict group
+    (ignoring extra keys like ``data_dict`` that come with the climhealth file)."""
+    return {role: OmegaConf.to_container(cfg.var_dict[role], resolve=True) for role in ROLES}
+
+
+def var_dict_size(var_dict):
+    return {role: sum(len(g["vars"]) for g in var_dict[role].values()) for role in ROLES}
+
+
+def get_canonical_nodes(min_year, max_year):
+    from legoloaderx.utils import get_unique_ids
+    z = str(REPO_ROOT / "data" / "input" / "lego" / "geoboundaries"
+            / "us_geoboundaries__census" / "us_uniqueid__census" / "zcta_yearly")
+    n, _ = get_unique_ids(z, min_year, max_year)
+    return sorted(n)
+
+
+def percentiles(xs):
+    a = np.asarray(xs)
+    return {"p50": float(np.percentile(a, 50)),
+            "p95": float(np.percentile(a, 95)),
+            "p99": float(np.percentile(a, 99)),
+            "mean": float(a.mean()),
+            "min": float(a.min()), "max": float(a.max()), "n": int(a.size)}
+
+
+def dir_size(p: Path):
+    """Return (logical_bytes, physical_bytes, file_count) under ``p``."""
+    if not p.exists():
+        return 0, 0, 0
+    lg = ph = n = 0
+    for f in p.rglob("*"):
+        if f.is_file():
+            st = f.stat()
+            lg += st.st_size
+            ph += st.st_blocks * 512
+            n += 1
+    return lg, ph, n
+
+
+def materialise(sample):
+    for v in sample.values():
+        if hasattr(v, "float"):
+            _ = v.float().sum().item()
+
+
+def make_dataset(cfg, var_dict, fmt, canonical, data_root):
+    return HealthXDataset(
+        root_dir=str(data_root),
+        var_dict=var_dict,
+        nodes=canonical,
+        window=cfg.window,
+        delta_t=cfg.delta_t,
+        file_format=fmt,
+        min_year=cfg.min_year,
+        max_year=cfg.max_year,
+    )
+
+
+# --------------------------------------------------------------------------
+# mode: formats
+# --------------------------------------------------------------------------
+
+def run_formats(cfg, var_dict, canonical, data_root):
+    results = []
+    for fmt in FORMATS:
+        print(f"\n[formats:{fmt}]")
+        disks = {}
+        for role in ROLES:
+            role_dir = "health" if role == "outcomes" else "covars"
+            for vg, vd in var_dict[role].items():
+                for v in vd["vars"]:
+                    if fmt == "yearly_mmap_sparse" and role != "outcomes":
+                        continue  # covariates always read dense
+                    lg, ph, nf = dir_size(data_root / role_dir / vg / v / fmt)
+                    disks[f"{role}/{vg}/{v}"] = {
+                        "disk_logical_mb": lg / 1e6,
+                        "disk_physical_mb": ph / 1e6,
+                        "n_files": nf,
+                    }
+        tot_lg = sum(d["disk_logical_mb"] for d in disks.values())
+        tot_ph = sum(d["disk_physical_mb"] for d in disks.values())
+        tot_nf = sum(d["n_files"] for d in disks.values())
+        print(f"  disk total: logical={tot_lg:8.2f} MB  physical={tot_ph:8.2f} MB  files={tot_nf}")
+
+        try:
+            ds = make_dataset(cfg, var_dict, fmt, canonical, data_root)
+            rng = np.random.default_rng(cfg.seed)
+            proc = psutil.Process()
+            rss0 = proc.memory_info().rss / 1e6
+
+            for w in range(4):  # warm-up
+                t0 = time.perf_counter()
+                materialise(ds[int(rng.integers(0, len(ds)))])
+                print(f"    warmup {w+1}/4: {(time.perf_counter()-t0)*1000.0:8.1f} ms", flush=True)
+
+            times, rss = [], []
+            for s in range(cfg.n_samples):
+                idx = int(rng.integers(0, len(ds)))
+                t0 = time.perf_counter()
+                materialise(ds[idx])
+                dt = (time.perf_counter() - t0) * 1000.0
+                times.append(dt)
+                rss.append(proc.memory_info().rss / 1e6)
+                print(f"    sample {s+1}/{cfg.n_samples}: {dt:8.1f} ms", flush=True)
+        except Exception as e:
+            print(f"  read FAILED: {e}")
+            results.append({"format": fmt, "error": str(e), "disks": disks})
+            continue
+
+        pct = percentiles(times)
+        rss_mb = {"init": rss0, "mean_during": float(np.mean(rss)),
+                  "peak_during": float(np.max(rss)),
+                  "growth_during": float(np.max(rss) - rss0)}
+        print(f"  read p50={pct['p50']:7.2f} ms  p95={pct['p95']:7.2f} ms  (n={pct['n']})")
+        print(f"  rss  init={rss_mb['init']:.0f} MB  mean={rss_mb['mean_during']:.0f} MB  "
+              f"peak={rss_mb['peak_during']:.0f} MB  growth={rss_mb['growth_during']:.0f} MB")
+        results.append({"format": fmt, "read_ms": pct, "rss_mb": rss_mb, "disks": disks,
+                        "disk_logical_mb_total": tot_lg, "disk_physical_mb_total": tot_ph,
+                        "n_files_total": tot_nf})
+    return results
+
+
+def plot_formats(results, size, cfg):
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    PLOTS_DIR.mkdir(parents=True, exist_ok=True)
+    fig, ax = plt.subplots(figsize=(8, 5))
+    for r in results:
+        if "read_ms" not in r:
+            continue
+        ax.scatter([r["disk_physical_mb_total"]], [r["read_ms"]["p50"]],
+                   s=170, edgecolor="black", linewidth=0.5, zorder=3)
+        ax.annotate(r["format"], (r["disk_physical_mb_total"], r["read_ms"]["p50"]),
+                    textcoords="offset points", xytext=(7, 7), fontsize=9)
+    ax.set_xscale("log"); ax.set_yscale("log")
+    ax.set_xlabel("Total physical disk (MB, log)")
+    ax.set_ylabel("HealthXDataset read p50 (ms, log)")
+    ax.set_title(f"Storage-format trade-off (var_dict: "
+                 f"{size['outcomes']} outcomes + {size['treatments']} treatments + "
+                 f"{size['confounders']} confounders, window={cfg.window}, "
+                 f"delta_t={cfg.delta_t}, n={cfg.n_samples})")
+    ax.grid(True, alpha=0.3, which="both")
+    fig.tight_layout()
+    fig.savefig(PLOTS_DIR / "format_benchmarks.png", dpi=140)
+    plt.close(fig)
+    print(f"→ wrote {PLOTS_DIR / 'format_benchmarks.png'}")
+
+
+# --------------------------------------------------------------------------
+# mode: scaling
+# --------------------------------------------------------------------------
+
+def _tree_rss_mb(proc):
+    """Total RSS (MB) of `proc` + all its children, and the worker count.
+
+    With num_workers>0 each DataLoader worker is a SEPARATE process, so the
+    main process RSS does not see worker memory. We sum the whole tree so the
+    reported peak reflects what a training job actually consumes (the relevant
+    number for the per-worker memory budget).
+    """
+    total = proc.memory_info().rss
+    kids = proc.children(recursive=True)
+    for c in kids:
+        try:
+            total += c.memory_info().rss
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+    return total / 1e6, len(kids)
+
+
+def time_cell(ds, num_workers, batch_size, prefetch_factor, persistent_workers, n_batches):
+    proc = psutil.Process()
+    kw = dict(batch_size=batch_size, shuffle=True, num_workers=num_workers,
+              pin_memory=False,
+              persistent_workers=(persistent_workers and num_workers > 0))
+    if num_workers > 0:
+        kw["prefetch_factor"] = prefetch_factor
+    loader = DataLoader(ds, **kw)
+
+    rss0, _ = _tree_rss_mb(proc)
+    batch_times, rss = [], [rss0]
+    max_kids = 0
+    t_start = last = time.perf_counter()
+    seen = nb = 0
+    for batch in loader:
+        now = time.perf_counter()
+        batch_times.append((now - last) * 1000.0)
+        last = now
+        seen += batch_size
+        nb += 1
+        tree_rss, n_kids = _tree_rss_mb(proc)   # main + worker processes
+        rss.append(tree_rss)
+        max_kids = max(max_kids, n_kids)
+        if nb >= n_batches:
+            break
+    elapsed = time.perf_counter() - t_start
+    sps = seen / elapsed if elapsed > 0 else 0.0
+
+    peak = float(np.max(rss))
+    # per-worker RSS budget: total tree peak divided across the live worker
+    # processes (>=1 to avoid div-by-zero for the nw=0 single-process case).
+    per_worker = peak / max(max_kids, 1)
+
+    del loader
+    gc.collect()
+    return {
+        "num_workers": num_workers, "batch_size": batch_size,
+        "prefetch_factor": prefetch_factor if num_workers > 0 else None,
+        "persistent_workers": bool(persistent_workers and num_workers > 0),
+        "n_batches": nb, "samples_seen": seen,
+        "samples_per_sec": sps, "ms_per_sample": 1000.0 / sps if sps > 0 else float("inf"),
+        # One sample = one lead-date = one day of training data; 365 samples = one
+        # data-year. This normalises out the dataset's year span (a full epoch
+        # scales with it, this does not).
+        "seconds_per_data_year": 365.0 / sps if sps > 0 else float("inf"),
+        "elapsed_s": elapsed,
+        "per_batch_ms_after_first": percentiles(batch_times[1:]) if len(batch_times) > 1 else None,
+        # RSS is the whole process tree (main + workers) in MB.
+        "rss_mb": {"init": rss0, "mean_during": float(np.mean(rss)),
+                   "peak_during": peak, "growth_during": peak - rss0,
+                   "peak_per_worker": per_worker, "max_worker_procs": max_kids},
+    }
+
+
+def run_scaling(cfg, var_dict, canonical, data_root):
+    print("\n[scaling] building dataset (yearly_mmap_dense)...")
+    t0 = time.perf_counter()
+    ds = make_dataset(cfg, var_dict, "yearly_mmap_dense", canonical, data_root)
+    init_ms = (time.perf_counter() - t0) * 1000.0
+    print(f"  init_ms={init_ms:.1f}, len={len(ds)}")
+
+    rng = np.random.default_rng(cfg.seed)
+    for _ in range(8):  # warm OS page cache
+        _ = ds[int(rng.integers(0, len(ds)))]
+
+    print(f"  {'nw':>3} {'bs':>3} {'pf':>3} {'pers':>5}  "
+          f"{'sps':>7}  {'s/yr':>7}  {'rss_peak':>9}  {'rss/wkr':>8}  {'procs':>5}")
+    cells = []
+    for nw in cfg.num_workers:
+        for bs in cfg.batch_sizes:
+            pfs = [None] if nw == 0 else list(cfg.prefetch)
+            for pf in pfs:
+                r = time_cell(ds, nw, bs, pf or 2, nw > 0, cfg.n_batches)
+                cells.append(r)
+                m = r["rss_mb"]
+                print(f"  {nw:>3} {bs:>3} {str(pf or '—'):>3} {str(r['persistent_workers']):>5}  "
+                      f"{r['samples_per_sec']:>7.2f}  {r['seconds_per_data_year']:>7.1f}  "
+                      f"{m['peak_during']:>9.0f}  {m['peak_per_worker']:>8.0f}  {m['max_worker_procs']:>5}")
+    best = min((c for c in cells if c["samples_per_sec"] > 0),
+               key=lambda c: c["seconds_per_data_year"], default=None)
+    if best:
+        print(f"  best: {best['seconds_per_data_year']:.1f} s per data-year "
+              f"(nw={best['num_workers']}, bs={best['batch_size']}, "
+              f"pf={best['prefetch_factor']})")
+    return {"init_ms": init_ms, "n_lead_dates": len(ds), "cells": cells}
+
+
+def plot_scaling(scaling, size, cfg, n_nodes):
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    PLOTS_DIR.mkdir(parents=True, exist_ok=True)
+    cells = scaling["cells"]
+    fig, ax = plt.subplots(figsize=(8, 5))
+    for bs in cfg.batch_sizes:
+        for pf in cfg.prefetch:
+            xs = sorted({c["num_workers"] for c in cells if c["batch_size"] == bs})
+            ys = []
+            for x in xs:
+                m = [c for c in cells if c["num_workers"] == x and c["batch_size"] == bs
+                     and (x == 0 or c["prefetch_factor"] == pf)]
+                ys.append(m[0]["samples_per_sec"] if m else 0.0)
+            ax.plot(xs, ys, marker="o", label=f"bs={bs}, prefetch={pf}")
+    ax.set_xlabel("num_workers")
+    ax.set_ylabel("samples / second (HealthXDataset)")
+    ax.set_title(f"DataLoader scaling — {n_nodes} ZCTAs, window={cfg.window}, "
+                 f"delta_t={cfg.delta_t}, var_dict "
+                 f"({size['outcomes']}+{size['treatments']}+{size['confounders']})")
+    ax.legend(fontsize=7); ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(PLOTS_DIR / "scaling.png", dpi=140)
+    plt.close(fig)
+    print(f"→ wrote {PLOTS_DIR / 'scaling.png'}")
+
+
+# --------------------------------------------------------------------------
+
+@hydra.main(config_path="../conf", config_name="benchmark", version_base=None)
+def main(cfg: DictConfig):
+    data_root = Path(cfg.data_root).resolve()
+    var_dict = build_var_dict(cfg)
+    size = var_dict_size(var_dict)
+    canonical = get_canonical_nodes(cfg.min_year, cfg.max_year)
+
+    print(f"[benchmark] host={socket.gethostname()} mode={cfg.mode} data_root={data_root}")
+    print(f"  var_dict: outcomes={size['outcomes']}, treatments={size['treatments']}, "
+          f"confounders={size['confounders']}")
+    print(f"  canonical zctas: {len(canonical)}; years {cfg.min_year}-{cfg.max_year}; "
+          f"window={cfg.window}, delta_t={cfg.delta_t}")
+
+    out = {
+        "host": socket.gethostname(),
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "mode": cfg.mode,
+        "data_root": str(data_root),
+        "var_dict_size": size,
+        "config": OmegaConf.to_container(cfg, resolve=True),
+        "n_nodes": len(canonical),
+    }
+
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    if cfg.mode in ("formats", "all"):
+        print(f"\n=== format comparison (n_samples={cfg.n_samples}) ===")
+        fmt_results = run_formats(cfg, var_dict, canonical, data_root)
+        out["formats"] = fmt_results
+        (RESULTS_DIR / "format_benchmarks.json").write_text(json.dumps(out, indent=2))
+        print(f"→ wrote {RESULTS_DIR / 'format_benchmarks.json'}")
+        try:
+            plot_formats(fmt_results, size, cfg)
+        except Exception as e:
+            print(f"format plot failed: {e}")
+
+    if cfg.mode in ("scaling", "all"):
+        print(f"\n=== scaling sweep (n_batches={cfg.n_batches}) ===")
+        scaling = run_scaling(cfg, var_dict, canonical, data_root)
+        out["scaling"] = scaling
+        (RESULTS_DIR / "scaling.json").write_text(json.dumps(out, indent=2))
+        print(f"→ wrote {RESULTS_DIR / 'scaling.json'}")
+        try:
+            plot_scaling(scaling, size, cfg, len(canonical))
+        except Exception as e:
+            print(f"scaling plot failed: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarking/benchmark.py
+++ b/benchmarking/benchmark.py
@@ -1,26 +1,54 @@
 """Main benchmarking script for HealthXDataset.
 
-Two modes, selected by ``mode`` (formats | scaling | all):
+Three modes, selected by ``mode`` (formats | scaling | traintime | all):
 
-  formats   For each on-disk format (daily_parquet, yearly_mmap_dense,
-            yearly_mmap_sparse) time `n_samples` random ``__getitem__`` reads
-            and record read latency, RSS, and on-disk size.
-  scaling   On yearly_mmap_dense, sweep (num_workers, batch_size, prefetch) and
-            measure DataLoader throughput over `n_batches` batches per cell.
+  formats    For each on-disk format (daily_parquet, yearly_mmap_dense,
+             yearly_mmap_sparse) time `n_samples` random ``__getitem__`` reads
+             and record read latency, RSS, and on-disk size.
+  scaling    Sweep (num_workers, batch_size, prefetch) on ``scaling_format``
+             (default yearly_mmap_dense) and measure raw DataLoader throughput
+             + whole-tree RSS over `n_batches` batches per cell.
+  traintime  The question that actually decides training: does the loader hide
+             behind the GPU step? Simulate the step with ``time.sleep(train_t)``
+             per batch (train_t≈2 s for a ~100M bf16 model on an H100), run a
+             real DataLoader sweeping (num_workers, prefetch_factor), and report
+             ``stall = wall - n_batches*train_t`` — the time the GPU would sit
+             idle waiting for data. stall ≈ 0 ⇒ the loader is NOT the bottleneck.
+
+The yearly mmaps are stored transposed ``(day, zcta)``, so a ``window``-day read
+is one contiguous row-slice; the loaders mmap them lazily per worker.
+
+Two levers govern whether the loader keeps up — and they are the whole story:
+  1. Storage substrate (``data_root``). ``data_root=data`` reads the shared NFS
+     store; ``data_root=/dev/shm/legoloaderx_data`` reads node-local RAM after
+     staging with ``benchmarking/stage_shm.sh``. Many concurrent workers reading
+     mmaps from NFS thrash on read contention (8 workers ~79 s first sample);
+     from /dev/shm they are healthy (~0.17 s/sample, nw=8). The format ranking
+     even FLIPS with substrate — on NFS sparse wins (fewer bytes over the wire);
+     on /dev/shm dense wins (RAM has no bandwidth limit, so CSR densify CPU cost
+     dominates). daily_parquet is far slower either way and OOM-prone at high
+     worker counts (~7,600 tiny file-opens/sample vs ~92 for the mmaps).
+     Production = dense on /dev/shm.
+  2. Prefetch (``prefetch_factor``). With workers prefetching ahead during the
+     simulated step, the per-sample gather overlaps with training; raising
+     prefetch is what collapses ``stall`` toward 0. (PyTorch has no
+     prefetch_factor=0; pf=1 == no prefetch-ahead. nw=0 has no prefetch and is
+     the fully-serial worst-case baseline.)
 
 Everything is driven by Hydra (``conf/benchmark.yaml``). The ``var_dict`` is a
 shared config group (``conf/var_dict/``) mirroring the climhealth workload, so
 the same file feeds the loaders and this benchmark. Override on the CLI, e.g.
 
     python benchmarking/benchmark.py var_dict=lego_small mode=formats
-    python benchmarking/benchmark.py n_samples=100 batch_sizes=[32,64] n_batches=15
+    python benchmarking/benchmark.py mode=traintime data_root=/dev/shm/legoloaderx_data \
+        train_t=2.0 scaling_format=yearly_mmap_dense
 
 Build the formats first via
     snakemake -s snakefile.smk         --cores N --config format=<fmt>
     snakemake -s snakefile_health.smk  --cores N --config format=<fmt>
 """
 from __future__ import annotations
-import gc, json, socket, sys, time
+import gc, json, socket, time
 from pathlib import Path
 
 
@@ -29,7 +57,7 @@ import numpy as np
 import psutil
 import torch
 from omegaconf import DictConfig, OmegaConf
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, Subset
 
 from legoloaderx import HealthXDataset
 
@@ -270,9 +298,10 @@ def time_cell(ds, num_workers, batch_size, prefetch_factor, persistent_workers, 
 
 
 def run_scaling(cfg, var_dict, canonical, data_root):
-    print("\n[scaling] building dataset (yearly_mmap_dense)...")
+    fmt = cfg.scaling_format
+    print(f"\n[scaling] building dataset ({fmt})...")
     t0 = time.perf_counter()
-    ds = make_dataset(cfg, var_dict, "yearly_mmap_dense", canonical, data_root)
+    ds = make_dataset(cfg, var_dict, fmt, canonical, data_root)
     init_ms = (time.perf_counter() - t0) * 1000.0
     print(f"  init_ms={init_ms:.1f}, len={len(ds)}")
 
@@ -331,6 +360,89 @@ def plot_scaling(scaling, size, cfg, n_nodes):
 
 
 # --------------------------------------------------------------------------
+# mode: traintime
+# --------------------------------------------------------------------------
+
+def traintime_cell(ds, pool, num_workers, prefetch_factor, train_t):
+    """Run one optimizer unit (`len(pool)` batches of batch_size 1) through a real
+    DataLoader, sleeping `train_t` s after each batch to stand in for the GPU step.
+
+    Returns whether the gather hides behind training. `ttfb` (worker spawn + first
+    page-in) is measured on a warmup sample and NOT charged to the unit, since it
+    is a one-time startup cost. `stall = wall - n_batches*train_t` is the GPU idle
+    time; ~0 means the loader keeps up.
+    """
+    proc = psutil.Process()
+    kw = dict(batch_size=1, shuffle=False, num_workers=num_workers,
+              persistent_workers=num_workers > 0)
+    if num_workers > 0:
+        kw["prefetch_factor"] = prefetch_factor
+    loader = DataLoader(Subset(ds, pool), **kw)
+    n_batches = len(pool)
+
+    it = iter(loader)
+    t0 = time.perf_counter()
+    next(it)                                   # warmup: spawn workers, page in
+    ttfb = time.perf_counter() - t0
+    time.sleep(train_t)                        # "train" the warmup batch too
+    rss_peak, _ = _tree_rss_mb(proc)
+
+    t_unit = time.perf_counter()
+    consumed = 1
+    for _ in it:
+        tr, _ = _tree_rss_mb(proc)
+        rss_peak = max(rss_peak, tr)
+        time.sleep(train_t)                    # GPU step stand-in
+        consumed += 1
+    rest = time.perf_counter() - t_unit
+
+    wall = ttfb + train_t + rest               # full unit wall-clock
+    floor = n_batches * train_t                # ideal: pure training
+    stall = wall - floor                       # gather NOT hidden by training
+    n_kids = len(proc.children(recursive=True))
+    del loader, it
+    gc.collect()
+    return {
+        "num_workers": num_workers,
+        "prefetch_factor": prefetch_factor if num_workers > 0 else None,
+        "n_batches": consumed, "train_t": train_t,
+        "ttfb_s": ttfb, "wall_s": wall, "floor_s": floor,
+        "stall_s": stall, "stall_pct": 100.0 * stall / wall if wall > 0 else 0.0,
+        "rss_peak_gb": rss_peak / 1e3, "rss_per_worker_gb": rss_peak / 1e3 / max(n_kids, 1),
+    }
+
+
+def run_traintime(cfg, var_dict, canonical, data_root):
+    fmt = cfg.scaling_format
+    train_t = cfg.train_t
+    n_batches = cfg.unit_batches
+    print(f"\n[traintime] building dataset ({fmt}); unit={n_batches} batches, "
+          f"train_t={train_t}s/batch, floor={n_batches * train_t:.1f}s")
+    ds = make_dataset(cfg, var_dict, fmt, canonical, data_root)
+    rng = np.random.default_rng(cfg.seed)
+    pool = [int(rng.integers(0, len(ds))) for _ in range(n_batches)]  # fixed, reused per cell
+
+    print(f"  {'nw':>3} {'pf':>3} {'ttfb_s':>8} {'wall_s':>8} {'floor_s':>8} "
+          f"{'stall_s':>8} {'stall%':>7} {'rss_pk':>7} {'rss/wkr':>8}")
+    cells = []
+    for nw in cfg.traintime_workers:
+        pfs = [None] if nw == 0 else list(cfg.traintime_prefetch)
+        for pf in pfs:
+            r = traintime_cell(ds, pool, nw, pf or 2, train_t)
+            cells.append(r)
+            print(f"  {nw:>3} {str(pf or '—'):>3} {r['ttfb_s']:>8.2f} {r['wall_s']:>8.2f} "
+                  f"{r['floor_s']:>8.2f} {r['stall_s']:>8.2f} {r['stall_pct']:>6.1f}% "
+                  f"{r['rss_peak_gb']:>7.2f} {r['rss_per_worker_gb']:>8.2f}")
+    best = min(cells, key=lambda c: c["stall_s"], default=None)
+    if best:
+        print(f"  best: stall={best['stall_s']:.2f}s ({best['stall_pct']:.1f}%) "
+              f"at nw={best['num_workers']}, pf={best['prefetch_factor']} "
+              f"(stall≈0 ⇒ loader hidden behind the {train_t}s step)")
+    return {"format": fmt, "train_t": train_t, "unit_batches": n_batches,
+            "n_lead_dates": len(ds), "cells": cells}
+
+
+# --------------------------------------------------------------------------
 
 @hydra.main(config_path="../conf", config_name="benchmark", version_base=None)
 def main(cfg: DictConfig):
@@ -377,6 +489,13 @@ def main(cfg: DictConfig):
             plot_scaling(scaling, size, cfg, len(canonical))
         except Exception as e:
             print(f"scaling plot failed: {e}")
+
+    if cfg.mode in ("traintime", "all"):
+        print(f"\n=== train-time simulation (train_t={cfg.train_t}s/batch) ===")
+        traintime = run_traintime(cfg, var_dict, canonical, data_root)
+        out["traintime"] = traintime
+        (RESULTS_DIR / "traintime.json").write_text(json.dumps(out, indent=2))
+        print(f"→ wrote {RESULTS_DIR / 'traintime.json'}")
 
 
 if __name__ == "__main__":

--- a/benchmarking/jobs/benchmark.sbatch
+++ b/benchmarking/jobs/benchmark.sbatch
@@ -1,0 +1,22 @@
+#!/bin/bash
+#SBATCH --job-name=legoloaderx-benchmark
+#SBATCH --output=benchmarking/jobs/benchmark_%j.out
+#SBATCH --partition=shared
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=32G
+#SBATCH --time=12:00:00
+
+# Full-scale HealthXDataset benchmark (format comparison + DataLoader scaling).
+# The short interactive run can be done directly on a compute node:
+#   python benchmarking/benchmark.py
+# Use this SLURM job for the long confidence run (full epoch), e.g.:
+#   sbatch benchmarking/jobs/benchmark.sbatch n_samples=200 batch_sizes=[32,64] n_batches=15
+
+set -euo pipefail
+
+source activate healthx 2>/dev/null || conda activate healthx 2>/dev/null || true
+cd "${SLURM_SUBMIT_DIR:-.}"
+
+python benchmarking/benchmark.py "$@"

--- a/benchmarking/stage_shm.sh
+++ b/benchmarking/stage_shm.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Stage the post-processed mmap store into node-local /dev/shm (RAM) so the
+# DataLoader benchmark / training reads from RAM instead of the shared NFS mount
+# (NFS read contention is what stalls many-worker loaders). Run ON the compute
+# node. The tarball holds BOTH formats (yearly_mmap_dense + yearly_mmap_sparse)
+# and idx2zcta. TARBALL / DST overridable via env. Logs to benchmarking/stage_shm.log.
+#
+#   bash benchmarking/stage_shm.sh
+#   python benchmarking/benchmark.py mode=traintime data_root=/dev/shm/legoloaderx_data
+set -euo pipefail
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)   # benchmarking/
+REPO=$(dirname "$HERE")
+TARBALL=${TARBALL:-/n/dominici_lab/lab/lego_loader_x/legoloaderx_mmaps.tar}
+DST=${DST:-/dev/shm/legoloaderx_data}
+LOG="$HERE/stage_shm.log"
+: > "$LOG"
+echo "host=$(hostname) tarball=$TARBALL dst=$DST" >> "$LOG"
+
+rm -rf "$DST"; mkdir -p "$DST"
+t0=$(date +%s.%N)
+tar -C "$DST" -xf "$TARBALL"
+t1=$(date +%s.%N)
+NF=$(find "$DST" -type f | wc -l); SZ=$(du -sh "$DST" | cut -f1)
+echo "unpacked $NF files ($SZ) in $(echo "$t1-$t0" | bc)s" >> "$LOG"
+
+# The tar stores paths as output/... and health_synthetic/...; the loaders expect
+# root_dir to contain covars/ and health/ -> symlink so data_root=$DST works as-is.
+ln -sfn "$DST/output" "$DST/covars"
+ln -sfn "$DST/health_synthetic" "$DST/health"
+echo "symlinks: covars->output, health->health_synthetic" >> "$LOG"
+echo DONE >> "$LOG"
+cat "$LOG"

--- a/conf/benchmark.yaml
+++ b/conf/benchmark.yaml
@@ -1,0 +1,37 @@
+# Config for benchmarking/benchmark.py (the main benchmarking script).
+# `var_dict` is a shared config group (conf/var_dict/) so the same file feeds
+# both the package loaders and downstream consumers (e.g. climhealth main.py).
+
+defaults:
+  - var_dict: lego          # lego | lego_small
+  - _self_
+
+data_root: data
+window: 30
+delta_t: 180
+
+# Year range only bounds the index pool we sample from — the loader is lazy, so
+# each read touches exactly `window + delta_t` days regardless of the span.
+# Timing is governed by sample/batch counts below, not by the year range.
+# Use the outcomes (ccw) built span 2000-2014; covars span wider.
+min_year: 2000
+max_year: 2014
+seed: 42
+
+mode: all                   # formats | scaling | all
+
+# --- format comparison: time `n_samples` random __getitem__ reads per format ---
+# The per-sample spread is the latency distribution; no outer repetition needed.
+n_samples: 10               # short test; raise for the long confidence run
+
+# --- scaling sweep (yearly_mmap_dense): vary DataLoader params, measure sps ---
+# For each (num_workers, batch_size, prefetch) cell, draw `n_batches` batches.
+# Short test below; the confidence run uses batch_sizes [32, 64] and n_batches 10-19.
+n_batches: 5
+num_workers: [0, 2, 4, 8]
+batch_sizes: [1, 4]
+prefetch: [1, 2, 4]
+
+hydra:
+  run:
+    dir: logs/benchmark/${now:%Y-%m-%d}/${now:%H-%M-%S}

--- a/conf/benchmark.yaml
+++ b/conf/benchmark.yaml
@@ -18,7 +18,7 @@ min_year: 2000
 max_year: 2014
 seed: 42
 
-mode: all                   # formats | scaling | all
+mode: all                   # formats | scaling | traintime | all
 
 # --- format comparison: time `n_samples` random __getitem__ reads per format ---
 # The per-sample spread is the latency distribution; no outer repetition needed.
@@ -31,6 +31,18 @@ n_batches: 5
 num_workers: [0, 2, 4, 8]
 batch_sizes: [1, 4]
 prefetch: [1, 2, 4]
+scaling_format: yearly_mmap_dense   # which built format scaling/traintime read
+
+# --- train-time simulation: does the loader hide behind the GPU step? ---
+# Run `unit_batches` batches of batch_size 1 through a real DataLoader, sleeping
+# `train_t` s after each batch to stand in for the GPU step, and report `stall`
+# (GPU idle time waiting on data; ~0 == loader keeps up). Sweeps `traintime_workers`
+# x `traintime_prefetch` (prefetch applies only when num_workers>0; nw=0 is the
+# fully-serial baseline). Reads `scaling_format` (dense | sparse) from `data_root`.
+train_t: 2.0                # s per step; ~2 s for a ~100M bf16 model on an H100
+unit_batches: 32            # batches per optimizer unit
+traintime_workers: [0, 4, 16]
+traintime_prefetch: [2]
 
 hydra:
   run:

--- a/conf/conf.yaml
+++ b/conf/conf.yaml
@@ -18,6 +18,9 @@ output_dir: data/output/
 uniqid_nm: us_uniqueid__census
 uniqid_dir: lego/geoboundaries/us_geoboundaries__census/
 
+format: daily_parquet  # daily_parquet | yearly_mmap_dense
+target: var_year       # var_year | canonical_zctas
+
 hydra:
   run:
     dir: logs/preprocessing/${now:%Y-%m-%d}/${now:%H-%M-%S}

--- a/conf/health/config.yaml
+++ b/conf/health/config.yaml
@@ -1,5 +1,4 @@
 year: 2010
-horizons: [30, 90, 180] # Horizons in days | must be in data
 
 var: diabetes
 
@@ -18,6 +17,9 @@ min_temporal_res: daily
 vg_name: ccw
 lego_prefix: sparse_counts
 lego_dir: lego/medicare/
+
+format: daily_parquet  # daily_parquet | yearly_mmap_dense | yearly_mmap_sparse
+target: var_year       # var_year | canonical_zctas
 
 hydra:
   run:

--- a/conf/health/snakemake.yaml
+++ b/conf/health/snakemake.yaml
@@ -6,13 +6,14 @@ vars: ['anemia', 'ami', 'alzh', 'alzhdmta', 'atrialfb', 'cataract',
       'endometrialCancer', 'hyperp', 'glaucoma', 'hipfrac', 'ischmcht', 
       'depressn', 'osteoprs', 'ra_oa', 'asthma', 'hyperl', 'hypert', 
       'hypoth']
-horizons: [30, 90, 180] 
 
 # depending on the choice of synthetic, read from different dirs
 use_synthetic: true
 
 lego_dir: lego/medicare
 synthetic_lego_dir: lego/medicare_synthetic
+
+format: daily_parquet  # daily_parquet | yearly_mmap_dense | yearly_mmap_sparse
 
 
 # Horizons in days

--- a/conf/snakemake.yaml
+++ b/conf/snakemake.yaml
@@ -2,3 +2,4 @@ var_groups: [gridmet, pm25_ushap, census, climate_types, aqdh]
 min_year: 2000
 max_year: 2020
 max_days: null # just for testing purposes
+format: daily_parquet  # daily_parquet | yearly_mmap_dense

--- a/conf/var_dict/lego.yaml
+++ b/conf/var_dict/lego.yaml
@@ -1,0 +1,165 @@
+treatments:
+  aqdh:
+    spatial_res: zcta
+    temporal_res: daily
+    vars:
+      - pm25
+      - no2
+      - o3
+  gridmet:
+    spatial_res: zcta
+    temporal_res: daily
+    vars:
+      - sph
+      - vpd
+      - tmmn
+      - tmmx
+      - pr
+      - rmin
+      - rmax
+      - srad
+      - vs
+      - th
+  pm25_ushap:
+    spatial_res: zcta
+    temporal_res: daily
+    vars:
+      - PM25
+
+confounders:
+  census:
+    spatial_res: zcta
+    temporal_res: yearly
+    vars:
+      - housing_occupied
+      - housing_owner_occupied
+      - housing_renter_occupied
+      - housing_units
+      - median_age
+      - median_home_value
+      - median_household_income
+      - pop_35_49_years
+      - pop_50_64_years
+      - pop_asian
+      - pop_black
+      - pop_higher_education_attained
+      - pop_higher_education_enrolled
+      - pop_hispanic
+      - pop_native
+      - pop_non_us_citizen
+      - pop_over_65_years
+      - pop_poverty
+      - population
+      - pop_under_20_years
+      - pop_white
+  climate_types:
+    spatial_res: zcta
+    temporal_res: yearly
+    vars:
+      - Af
+      - Am
+      - Aw
+      - BWh
+      - BWk
+      - BSh
+      - BSk
+      - Csa
+      - Csb
+      - Csc
+      - Cwa
+      - Cwb
+      - Cwc
+      - Cfa
+      - Cfb
+      - Cfc
+      - Dsa
+      - Dsb
+      - Dsc
+      - Dsd
+      - Dwa
+      - Dwb
+      - Dwc
+      - Dwd
+      - Dfa
+      - Dfb
+      - Dfc
+      - Dfd
+      - ET
+      - EF
+
+outcomes:
+  ccw:
+    spatial_res: zcta
+    temporal_res: yearly
+    vars:
+      - anemia
+      - ami
+      - alzh
+      - alzhdmta
+      - atrialfb
+      - cataract
+      - chrnkidn
+      - copd
+      - chf
+      - diabetes
+      - stroke
+      - breastCancer
+      - colorectalCancer
+      - prostateCancer
+      - lungCancer
+      - endometrialCancer
+      - hyperp
+      - glaucoma
+      - hipfrac
+      - ischmcht
+      - depressn
+      - osteoprs
+      - ra_oa
+      - asthma
+      - hyperl
+      - hypert
+      - hypoth
+
+
+
+data_dict:
+  pm25: "Particulate Matter (PM2.5) concentration in micrograms per cubic meter"
+  no2: "Nitrogen Dioxide (NO2) concentration in parts per billion"
+  o3: "Ozone (O3) concentration in parts per billion"
+  sph: "Specific Humidity (sph) in kg/kg"
+  vpd: "Vapor Pressure Deficit (vpd) in Pascals"
+  tmmn: "Minimum Temperature (tmmn) in degrees Celsius"
+  tmmx: "Maximum Temperature (tmmx) in degrees Celsius"
+  pr: "Precipitation (pr) in millimeters"
+  rmin: "Minimum Relative Humidity (rmin) in percentage"
+  rmax: "Maximum Relative Humidity (rmax) in percentage"
+  srad: "Solar Radiation (srad) in Watts per square meter"
+  vs: "Wind Speed (vs) in meters per second"
+  th: "Temperature Humidity Index (th) in degrees Celsius"
+  anemia: "Anemia including ICD10 codes: D50-D53, D55-D64"
+  ami: "Acute Myocardial Infarction including ICD10 codes: I21, I22"
+  alzh: "Alzheimer's Disease including ICD10 codes: G30"
+  alzhdmta: "Alzheimer's Disease and Related Disorders or Senile Dementia including ICD10 codes: F01.5, F02.8, F03.9, F04-F06, G13, G30, G31, G91.4, G94, R41.81, R54"
+  atrialfb: "Atrial Fibrillation including ICD10 codes: I48.0, I48.2, I48.91"
+  cataract: "Cataract including ICD10 codes: H25-H27, H43, Q12.0, Z96.1"
+  chrnkidn: "Chronic Kidney Disease including ICD10 codes: A18.11, B52.0, C64, C68.9, D30.0*, D41, D59.3, E08, E09, E10, E11, E13, E74.8, I12.0, I13, I70.1, I72.2, K76.7, M10.3, N00-N08, N13-N19, N25, N26, Q61, Q62, R94.4"
+  copd: "Chronic Obstructive Pulmonary Disease and Bronchiectasis including ICD10 codes: J40, J41, J42, J43, J44, J47"
+  chf: "Congestive Heart Failure including ICD10 codes: I09.81, I11.0, I13, I50"
+  diabetes: "Diabetes including ICD10 codes: E08, E09, E10, E11, E13"
+  stroke: "Stroke / Transient Ischemic Attack including ICD10 codes: G45, G46, G97, I60, I61,I63, I66,I67.8*, I97.8"
+  breastCancer: "Breast Cancer including ICD10 codes: C50.**, D05.**"
+  colorectalCancer: "Colorectal Cancer including ICD10 codes: C18.0, C18.1, C18.2, C18.3, C18.4, C18.5, C18.6, C18.7, C18.8, C18.9, C19, C20, D01.0, D01.1, D01.2, Z85.038, Z85.048"
+  prostateCancer: "Prostate Cancer including ICD10 codes: C61, D07.5, Z85.46"
+  lungCancer: "Lung Cancer including ICD10 codes: C34.00, C34.01, C34.02, C34.10, C34.11, C34.12, C34.2, C34.30, C34.31, C34.32, C34.80, C34.81, C34.82, C34.90, C34.91, C34.92, D02.20, D02.21, D02.22, Z85.118"
+  endometrialCancer: "Endometrial Cancer including ICD10 codes: C54.1, C54.2, C54.3, C54.9, D07.0, Z85.42."
+  hyperp: "Benign Prostatic Hyperplasia including ICD10 codes: N40, N42.83"
+  glaucoma: "Glaucoma including ICD10 codes: H35.89, H40, H47.23*"
+  hipfrac: "Hip/Pelvic Fracture including ICD10 codes: M80, M84, S32"
+  ischmcht: "Ischemic Heart Disease including ICD10 codes: I20, I21, I22, I24, I25"
+  depressn: "Depression including ICD10 codes: F31, F32, F33, F34.1"
+  osteoprs: "Osteoporosis including ICD10 codes: M81.0, M81.6, M81.8"
+  ra_oa: "Rheumatoid Arthritis / Osteoarthritis including ICD10 codes: M05, M06"
+  asthma: "Asthma including ICD10 codes: J44, J45"
+  hyperl: "Hyperlipidemia including ICD10 codes: E78.0, E78.1, E78.2, E78.3, E78.4, E78.5"
+  hypert: "Hypertension including ICD10 codes: H35.03*, I10, I11, I12, I13, I15, I67.4, N26.2"
+  hypoth: "Acquired Hypothyroidism including ICD10 codes: E01.8, E02, E03.2, E03.3, E03.8, E03.9, E89.0"

--- a/conf/var_dict/lego_small.yaml
+++ b/conf/var_dict/lego_small.yaml
@@ -1,0 +1,43 @@
+# Trimmed var_dict for fast real-data smoke tests.
+# Three vars per stream — enough to exercise the pipeline without the
+# full ~100-var footprint of `lego.yaml`. Names are drawn from the
+# upstream FeatureEmbeddings artifact vocab so `embedding.path=...`
+# continues to work; no vocab mismatch.
+
+treatments:
+  aqdh:
+    spatial_res: zcta
+    temporal_res: daily
+    vars:
+      - pm25
+      - no2
+      - o3
+
+confounders:
+  census:
+    spatial_res: zcta
+    temporal_res: yearly
+    vars:
+      - population
+      - median_age
+      - pop_poverty
+
+outcomes:
+  ccw:
+    spatial_res: zcta
+    temporal_res: daily
+    vars:
+      - anemia
+      - ami
+      - diabetes
+
+data_dict:
+  pm25: "Particulate Matter (PM2.5) concentration in micrograms per cubic meter"
+  no2: "Nitrogen Dioxide (NO2) concentration in parts per billion"
+  o3: "Ozone (O3) concentration in parts per billion"
+  population: "Total population"
+  median_age: "Median age of population"
+  pop_poverty: "Population below poverty line"
+  anemia: "Anemia including ICD10 codes: D50-D53, D55-D64"
+  ami: "Acute Myocardial Infarction including ICD10 codes: I21, I22"
+  diabetes: "Diabetes including ICD10 codes: E08, E09, E10, E11, E13"

--- a/conf/var_group/aqdh.yaml
+++ b/conf/var_group/aqdh.yaml
@@ -9,5 +9,5 @@ min_year: 2000
 max_year: 2016
 min_spatial_res: zcta
 min_temporal_res: daily
-lego_nm: air_pollution__aqdh__zcta_daily
-lego_dir: lego/environmental/air_pollution__aqdh/zcta_daily/
+lego_nm: air_pollution__schwartz__zcta_daily
+lego_dir: lego/environmental/air_pollution__schwartz/zcta_daily/

--- a/conf/var_group/climate_types.yaml
+++ b/conf/var_group/climate_types.yaml
@@ -51,3 +51,6 @@ min_spatial_res: zcta
 min_temporal_res: yearly
 lego_nm: climate_types__koppen_geiger__zcta_yearly
 lego_dir: lego/environmental/climate_types__koppen_geiger/present/zcta_yearly/
+# The koppen view stores per-zone area fractions as pct_<zone-lowercase>
+# (e.g. pct_af), while the canonical var / embedding key is the zone code (Af).
+lego_col: "pct_{var_lower}"

--- a/conf/var_group/gridmet.yaml
+++ b/conf/var_group/gridmet.yaml
@@ -17,5 +17,5 @@ max_year: 2020
 valid_normalize: true
 min_spatial_res: zcta
 min_temporal_res: daily
-lego_nm: meteorology__gridmet__zcta_daily
-lego_dir: lego/environmental/meteorology__gridmet/zcta_daily/
+lego_nm: meteorology__gridmet__core__zcta_daily
+lego_dir: lego/environmental/meteorology__gridmet/core/zcta_daily/

--- a/legoloaderx/health_dataloader.py
+++ b/legoloaderx/health_dataloader.py
@@ -1,8 +1,19 @@
+import os
+import calendar
+from datetime import date
+import numpy as np
 import pandas as pd
 import torch
 from torch.utils.data import DataLoader, Dataset
-import duckdb
 import pyarrow.parquet as pq
+import scipy.sparse
+
+from legoloaderx.utils import load_idx2zcta
+
+
+def _days_in_year(year):
+    return 366 if calendar.isleap(year) else 365
+
 
 class HealthDataset(Dataset):
     def __init__(
@@ -11,15 +22,17 @@ class HealthDataset(Dataset):
         var_dict, # var_dict is structured as {var_group: {"vars": [...], "temporal_res": ...}}
         nodes, # List of zctas
         window,
-        horizons: list[int] | None = None,
-        delta_t: int | None = None,
+        delta_t,
+        file_format="daily_parquet",
         min_year: int = 2000,
         max_year: int = 2020,
         min_bene: int = 10,
     ):
-        assert horizons is not None or delta_t is not None, "Either horizons or delta_t must be provided."
-        assert horizons is None or delta_t is None, "Only one of horizons or delta_t can be provided."
+        assert delta_t is not None and delta_t >= 0, "delta_t must be a non-negative integer"
+        assert file_format in ("daily_parquet", "yearly_mmap_dense", "yearly_mmap_sparse"), \
+            f"unknown file_format {file_format!r}"
         self.root_dir = root_dir
+        self.file_format = file_format
 
         self.var_dict = var_dict
         # Pull the vars for each var_group in var_dict
@@ -31,154 +44,213 @@ class HealthDataset(Dataset):
         self.var_to_idx = {var: i for i, var in enumerate(self.vars)}
 
         self.nodes = nodes
-        self.node_string = ",".join(f"'{node}'" for node in self.nodes)  # For SQL queries
         self.node_to_idx = {node: i for i, node in enumerate(self.nodes)}
 
         all_dates = pd.date_range(f"{min_year}-01-01", f"{max_year}-12-31", freq="D")
         self.yyyymmdd = [f"{d.year}{d.month:02d}{d.day:02d}"  for d in all_dates]
 
-        if horizons:
-            self.horizon_mode = "horizons"
-            self.horizons = list(sorted(horizons))
-            if 0 not in self.horizons:
-                self.horizons.insert(0, 0)
-            self.horizon_string = ",".join(map(str, self.horizons))  # For SQL queries
-            self.horizon_to_idx = {h: i for i, h in enumerate(horizons)}
-            self.lead_dates = self.yyyymmdd[window-1:]  # Dates for which we have window history
-            self.delta_t = None
-        else:
-            self.horizon_mode = "delta_t"
-            self.delta_t = delta_t
-            self.lead_dates = self.yyyymmdd[window-1:-delta_t]  # Dates for which we have window history
-            self.horizons = None
-            self.horizon_string = None
-            self.horizon_to_idx = None
+        self.delta_t = delta_t
+        self.lead_dates = self.yyyymmdd[window-1:-delta_t] if delta_t > 0 else self.yyyymmdd[window-1:]
 
         self.window = window
         self.min_bene = min_bene
 
+        # For non-parquet formats we mmap per-year arrays stored as
+        # (n_days, n_zctas). Resolve requested nodes → stored-index column
+        # indices once at init.
+        self._node_store_idx = None
+        self._identity_rows = False
+        if file_format != "daily_parquet":
+            idx2zcta = load_idx2zcta(self.root_dir)
+            zcta2idx = {z: i for i, z in enumerate(idx2zcta)}
+            node_idx = np.array([zcta2idx.get(z, -1) for z in nodes], dtype=np.int64)
+            if (node_idx < 0).any():
+                missing = int((node_idx < 0).sum())
+                raise ValueError(
+                    f"{missing} of {len(nodes)} requested nodes not in idx2zcta.txt at {self.root_dir}"
+                )
+            self._node_store_idx = node_idx
+            # Fast path: when the requested nodes are exactly the stored idx2zcta list
+            # in order, the per-read node-gather is a no-op and can be skipped.
+            self._identity_rows = (
+                len(node_idx) == len(idx2zcta)
+                and bool(np.array_equal(node_idx, np.arange(len(idx2zcta))))
+            )
+
     def __len__(self):
         return len(self.lead_dates)
 
-    def __getcounts_with_horizons(self, idx):
-        counts = torch.zeros((len(self.nodes), len(self.vars), len(self.horizons), self.window), dtype=torch.float32)
+    # ----- daily_parquet path: original main behaviour, with /{file_format}/ subdir -----
 
-        # for var in self.var_to_idx:
-        for var_group_name, var_group in self.var_dict.items():
-            # Like this start_date[idx] == self.yyyymmdd[idx + window - 1]
-            dates = self.yyyymmdd[idx:idx + self.window]
-
-            for var in var_group["vars"]:
-                # Get the index for the variable
-                var_index = self.var_to_idx[f"{var_group_name}_{var}"]
-
-                for date_idx, day in enumerate(dates):
-                    file = f"{self.root_dir}/{var_group_name}/{var}/{var}__{day}.parquet"
-                    
-                    if not os.path.exists(file):
-                        continue  # Skip if file doesn't exist
-                        
-                    table = pq.read_table(file).to_pandas()
-
-                    table["zcta_index"] = table["zcta"].apply(lambda z: self.node_to_idx.get(z, -1))
-                    table["horizon_index"] = table["horizon"].apply(lambda h: self.horizon_to_idx.get(h, -1))
-                    table = table[(table["zcta_index"] != -1) & (table["horizon_index"] != -1)]  # Filter out nodes not in self.node_to_idx
-                    zcta_index = torch.LongTensor(table["zcta_index"].values)
-                    horizon_index = torch.LongTensor(table["horizon_index"].values)
-                    n = torch.FloatTensor(table["n"].values)
-
-                    # Update the counts tensor
-                    counts[zcta_index, var_index, horizon_index, date_idx] = n
-
-        return counts
-
-    def __getcounts_with_delta_t(self, idx):
+    def _counts_parquet(self, idx):
         counts = torch.zeros((len(self.nodes), len(self.vars), self.window + self.delta_t), dtype=torch.float32)
 
         for var_group_name, var_group in self.var_dict.items():
-            # Like this start_date[idx] == self.yyyymmdd[idx + window - 1]
             dates = self.yyyymmdd[idx:idx + self.window + self.delta_t]
 
             for var in var_group["vars"]:
-                # Get the index for the variable
                 var_index = self.var_to_idx[f"{var_group_name}_{var}"]
 
                 for date_idx, day in enumerate(dates):
-                    file = f"{self.root_dir}/{var_group_name}/{var}/{var}__{day}.parquet"
+                    file = f"{self.root_dir}/{var_group_name}/{var}/{self.file_format}/{var}__{day}.parquet"
+                    if not os.path.exists(file):
+                        continue
 
                     table = pq.read_table(file).to_pandas()
-                    table = table[table["horizon"] == 0]
+                    if table.empty:
+                        continue
+                    table["zcta_index"] = table["zcta"].apply(lambda z: self.node_to_idx.get(z, -1))
+                    table = table[table["zcta_index"] != -1]
 
-                    if not table.empty:
-                        table["zcta_index"] = table["zcta"].apply(lambda z: self.node_to_idx.get(z, -1))
-                        table = table[table["zcta_index"] != -1]  # Filter out nodes not in self.node_to_idx
-
-                        zcta_index = torch.LongTensor(table["zcta_index"].values)
-                        n = torch.FloatTensor(table["n"].values)
-
-                        counts[zcta_index, var_index, date_idx] = n
+                    zcta_index = torch.LongTensor(table["zcta_index"].values)
+                    n = torch.FloatTensor(table["n"].values)
+                    counts[zcta_index, var_index, date_idx] = n
 
         return counts
 
-    def __getdenom_and_mask_counts(self, idx, counts):
-        dates = self.yyyymmdd[idx:idx + self.window + self.delta_t]
+    # ----- yearly_mmap_* path -----
 
-        _denom_cache = {}
-        denom = torch.zeros((len(self.nodes), self.window + self.delta_t), dtype=torch.float32)
+    def _year_chunks(self, idx, span):
+        days = self.yyyymmdd[idx:idx + span]
+        cursor = 0
+        while cursor < len(days):
+            day0 = days[cursor]
+            year = int(day0[:4])
+            year_days = _days_in_year(year)
+            doy0 = (
+                date(int(day0[:4]), int(day0[4:6]), int(day0[6:8]))
+                - date(year, 1, 1)
+            ).days
+            length = min(year_days - doy0, len(days) - cursor)
+            yield year, cursor, doy0, length
+            cursor += length
+
+    def _counts_mmap(self, idx):
+        span = self.window + self.delta_t
+        counts = np.zeros((len(self.nodes), len(self.vars), span), dtype=np.float32)
+        node_idx = self._node_store_idx
+        identity = self._identity_rows
+        sparse = (self.file_format == "yearly_mmap_sparse")
+        ext = "npz" if sparse else "npy"
+
+        # Files are (n_days, n_zctas): a day-window is a contiguous row-slice.
+        for var_group_name, var_group in self.var_dict.items():
+            for var in var_group["vars"]:
+                var_index = self.var_to_idx[f"{var_group_name}_{var}"]
+                for year, dst, doy0, length in self._year_chunks(idx, span):
+                    path = f"{self.root_dir}/{var_group_name}/{var}/{self.file_format}/{var}__{year}.{ext}"
+                    if not os.path.exists(path):
+                        continue
+                    if sparse:
+                        mm = scipy.sparse.load_npz(path)
+                        slc = mm[doy0:doy0 + length, :].toarray()      # (length, n_zctas)
+                    else:
+                        mm = np.load(path, mmap_mode="r")
+                        slc = np.ascontiguousarray(mm[doy0:doy0 + length, :])  # (length, n_zctas)
+                    # gather requested nodes on the column axis (skip if identity),
+                    # then place as (n_nodes, length).
+                    sel = slc if identity else slc[:, node_idx]
+                    counts[:, var_index, dst:dst + length] = sel.T.astype(np.float32, copy=False)
+
+        return torch.from_numpy(counts)
+
+    # ----- denom (format-aware) -----
+
+    def _denom_and_mask_counts(self, idx, counts):
+        span = self.window + self.delta_t
+        dates = self.yyyymmdd[idx:idx + span]
+        denom = torch.zeros((len(self.nodes), span), dtype=torch.float32)
+
+        # Local per-call denom cache (matches main's pattern — scoped to one
+        # __getitem__ call so it doesn't grow across calls).
+        denoms_this_call = {}
         for date_idx, day in enumerate(dates):
-            year = day[:4]
-
-            if year not in _denom_cache:
-                df = pq.read_table(f"{self.root_dir}/denom/denom__{year}.parquet").to_pandas()
-                df.loc[df.n_bene < self.min_bene, "n_bene"] = 0  # Mask out small counts
-                df["zcta_index"] = df["zcta"].map(lambda z: self.node_to_idx.get(z, -1))
-                df = df[df["zcta_index"] != -1]  # Filter out nodes not in self.node_to_idx
-                _denom_cache[year] = df
-
-            denom_df = _denom_cache[year]
-            denom_counts = torch.FloatTensor(denom_df.n_bene.values)
-            idxs = torch.LongTensor(denom_df.zcta_index.values)
-            denom[idxs, date_idx] = denom_counts
-            counts[idxs[denom_counts == 0], ..., date_idx] = torch.nan  # Mask counts where denom is zero
+            year_int = int(day[:4])
+            payload = denoms_this_call.get(year_int)
+            if payload is None:
+                payload = self._load_denom_year(year_int)
+                denoms_this_call[year_int] = payload
+            if payload is False:
+                continue
+            zcta_idx_t, n_bene_t, zero_mask_t = payload
+            denom[zcta_idx_t, date_idx] = n_bene_t
+            counts[zcta_idx_t[zero_mask_t], ..., date_idx] = torch.nan
 
         return denom
 
-    def __getitem__(self, idx):
-        if self.horizon_mode == "horizons":
-            counts = self.__getcounts_with_horizons(idx)
-        else:
-            counts = self.__getcounts_with_delta_t(idx)
+    def _load_denom_year(self, year):
+        """Return (zcta_idx_tensor, n_bene_tensor, zero_mask_tensor) for the given year.
+        zero_mask flags rows that are in source AND have n_bene < min_bene (so counts get NaN-masked).
+        """
+        if self.file_format == "daily_parquet":
+            path = f"{self.root_dir}/denom/{self.file_format}/denom__{year}.parquet"
+            if not os.path.exists(path):
+                return False
+            df = pq.read_table(path).to_pandas()
+            df["zcta_index"] = df["zcta"].map(lambda z: self.node_to_idx.get(z, -1))
+            df = df[df["zcta_index"] != -1]
+            n_bene = df["n_bene"].values.astype(np.float32)
+            zcta_idx = df["zcta_index"].values.astype(np.int64, copy=False)
+            zero_mask = n_bene < self.min_bene
+            n_bene[zero_mask] = 0
+            return (
+                torch.from_numpy(zcta_idx).long(),
+                torch.from_numpy(n_bene),
+                torch.from_numpy(zero_mask),
+            )
 
-        denom = self.__getdenom_and_mask_counts(idx, counts)
+        # yearly_mmap_*: dense int32 .npy with sentinel -1 for "missing from source".
+        # Denom is always written under /denom/yearly_mmap_dense/ even when outcomes
+        # use sparse, since denom is a single-vector-per-year and doesn't benefit
+        # from sparsity.
+        path = f"{self.root_dir}/denom/yearly_mmap_dense/denom__{year}.npy"
+        if not os.path.exists(path):
+            return False
+        arr = np.load(path, mmap_mode="r")[self._node_store_idx]
+        in_source = arr >= 0
+        n_bene = np.where(in_source, arr, 0).astype(np.float32)
+        zero_mask = in_source & (n_bene < self.min_bene)
+        n_bene[zero_mask] = 0
+        rows = np.arange(len(self.nodes), dtype=np.int64)
+        return (
+            torch.from_numpy(rows),
+            torch.from_numpy(n_bene),
+            torch.from_numpy(zero_mask),
+        )
+
+    def __getitem__(self, idx):
+        if self.file_format == "daily_parquet":
+            counts = self._counts_parquet(idx)
+        else:
+            counts = self._counts_mmap(idx)
+
+        denom = self._denom_and_mask_counts(idx, counts)
 
         return {
             "outcomes": counts,
             "denom": denom,
         }
 
+
 def main():
     root_dir = "data/health"
-    # Example var_dict structured like x_dataloader.py
     var_dict = {
         "ccw": {
             "vars": ["anemia", "asthma"],
             "temporal_res": "daily"
         }
     }
-    # print example  zcta list
-    nodes_list = ["00601", "00602"]  # Example zcta codes
+    nodes_list = ["00601", "00602"]
     window = 30
-    horizons = [0, 7, 14, 30]  # Example horizons
     delta_t = 180
     min_year = 2000
     max_year = 2014
 
     dataset = HealthDataset(root_dir, var_dict, nodes_list, window, delta_t=delta_t, min_year=min_year, max_year=max_year)
-    dataset = HealthDataset(root_dir, var_dict, nodes_list, window, horizons=horizons, min_year=min_year, max_year=max_year)
     dataloader = DataLoader(dataset, batch_size=2, shuffle=True, num_workers=0)
 
     for batch in dataloader:
-        print(batch['outcomes'].shape)  # Should print the shape of the batch tensor
+        print(batch['outcomes'].shape)
 
 if __name__ == "__main__":
     main()

--- a/legoloaderx/health_x_dataloader.py
+++ b/legoloaderx/health_x_dataloader.py
@@ -10,19 +10,20 @@ from omegaconf import DictConfig
 
 class HealthXDataset(Dataset):
     def __init__(
-            self, 
-            root_dir, 
-            var_dict, 
+            self,
+            root_dir,
+            var_dict,
             var_type=None,
-            nodes=None, 
-            window=None, 
-            horizons=None, 
-            delta_t=None, 
+            nodes=None,
+            window=None,
+            delta_t=None,
+            file_format="daily_parquet",
             normalize=False,
-            min_year=2000, 
+            min_year=2000,
             max_year=2020):
 
         self.root_dir = root_dir
+        self.file_format = file_format
         self.var_dict = var_dict
         self.normalize = normalize
         self.nodes = nodes
@@ -30,36 +31,26 @@ class HealthXDataset(Dataset):
         self.min_year = min_year
         self.max_year = max_year
 
-        # load normalization json if normalize is True
-        # if self.normalize:
-        #     norm_path = f"{self.root_dir}/normalization/normalization_stats.json"
-        #     # if the file does not exist, raise error
-        #     if not os.path.exists(norm_path):
-        #         raise FileNotFoundError(f"Normalization stats file not found at {norm_path}")
-        #     else:
-        #         with open(norm_path, 'r') as f:
-        #             self.normalization_stats = json.load(f)
-        # else:
-        #     self.normalization_stats = None
-
         self.outcomes_dataset = HealthDataset(
             root_dir=f"{self.root_dir}/health",
             var_dict=self.var_dict["outcomes"],
-            nodes=self.nodes,  # Use nodes_list directly
+            nodes=self.nodes,
             window=self.window,
-            horizons=horizons,
             delta_t=delta_t,
+            file_format=file_format,
             min_year=self.min_year,
             max_year=self.max_year
         )
-        self.horizons = self.outcomes_dataset.horizons
         self.delta_t = self.outcomes_dataset.delta_t
-       
+
+        # Covariate roles are always dense (sparse only applies to outcomes).
+        x_file_format = "yearly_mmap_dense" if file_format == "yearly_mmap_sparse" else file_format
         self.confounders_dataset = XDataset(
             root_dir=f"{self.root_dir}/covars",
             var_dict=self.var_dict["confounders"],
-            nodes=self.nodes,  # List of zctas or other nodes
+            nodes=self.nodes,
             window=self.window,
+            file_format=x_file_format,
             normalize=self.normalize,
             min_year=self.min_year,
             max_year=self.max_year
@@ -67,8 +58,9 @@ class HealthXDataset(Dataset):
         self.treatments_dataset = XDataset(
             root_dir=f"{self.root_dir}/covars",
             var_dict=self.var_dict["treatments"],
-            nodes=self.nodes,  # List of zctas or other nodes
+            nodes=self.nodes,
             window=self.window,
+            file_format=x_file_format,
             normalize=self.normalize,
             min_year=self.min_year,
             max_year=self.max_year

--- a/legoloaderx/utils.py
+++ b/legoloaderx/utils.py
@@ -153,12 +153,21 @@ def get_var_summy(summary_stats, var_group_name, var_name):
 
 
 # Function to get unique IDs from zcta parquet files over a year range
+def load_idx2zcta(root_dir):
+    """Read idx2zcta.txt at ``root_dir`` (the per-role read root).
+    Written once by the format pipeline; ordering is authoritative for the
+    yearly_mmap_* per-(var, year) arrays."""
+    path = os.path.join(root_dir, "idx2zcta.txt")
+    with open(path) as f:
+        return [line.strip() for line in f if line.strip()]
+
+
 def get_unique_ids(unique_fpath, min_yr, max_yr):
     total_uniq = []
     node_lst_dict = {} 
     
     query = duckdb.query(f"SELECT zcta, year, continental_us FROM '{unique_fpath}/*.parquet'")
-    all_df = query.fetchdf().set_index('year')
+    all_df = query.df().set_index('year')
     all_df = all_df[all_df.continental_us]  # Filter for continental US
     for yr in range(min_yr, max_yr+1):
         

--- a/legoloaderx/x_dataloader.py
+++ b/legoloaderx/x_dataloader.py
@@ -1,17 +1,23 @@
+import calendar
 import logging
 import os
 import time
 import json
+from datetime import date
 
 import hydra
+import numpy as np
 import torch
 import pandas as pd
 from omegaconf import DictConfig
 from torch.utils.data import DataLoader, Dataset
 from tqdm import tqdm
 import pyarrow.parquet as pq
-from legoloaderx.utils import compute_summary, load_summary_stats, get_var_summy, get_unique_ids
+from legoloaderx.utils import compute_summary, load_summary_stats, get_var_summy, get_unique_ids, load_idx2zcta
 
+
+def _days_in_year(year):
+    return 366 if calendar.isleap(year) else 365
 
 
 class XDataset(Dataset):
@@ -21,16 +27,20 @@ class XDataset(Dataset):
         var_dict, #var_dict is structured as {var_group: {"vars": [...], "temporal_res": ...}}
         nodes,  # List of zctas (required)
         window,   # Window size for temporal data (required)
+        file_format="daily_parquet",  # daily_parquet | yearly_mmap_dense
         transform=None, # not implemented right now
         min_year = 2000,
         max_year = 2020,
         normalize=False,  # Optional path or dict of summary stats
     ):
+        assert file_format in ("daily_parquet", "yearly_mmap_dense"), \
+            f"unknown file_format {file_format!r} for XDataset (sparse only applies to outcomes)"
         self.root_dir = root_dir
+        self.file_format = file_format
         self.transform = transform
         self.var_dict = var_dict
         self.window = window
-    
+
         if not normalize:
             self.summary_stats = None
         else:
@@ -39,50 +49,76 @@ class XDataset(Dataset):
         # Pull the vars for each var_group in var_dict
         self.vars = [f"{var_group_name}_{var}" for var_group_name, var_group in var_dict.items() for var in var_group["vars"]]
         self.var_to_idx = {var: i for i, var in enumerate(self.vars)}
-        
+
         # Handle nodes (zctas)
         self.nodes = nodes
         self.node_to_idx = {node: i for i, node in enumerate(self.nodes)}
-        
+
         all_dates = pd.date_range(f"{min_year}-01-01", f"{max_year}-12-31", freq="D")
         self.yyyymmdd = [f"{d.year}{d.month:02d}{d.day:02d}"  for d in all_dates]
-        
+
         # For windowed data, we need to start from window-1 to have enough history
         self.lead_dates = self.yyyymmdd[window-1:]
 
-        # For node assignment after reading parquet
+        # For daily_parquet: per-var_group row→zcta assignment cache (existing behaviour).
         self.row_to_zcta_assignments = {}
+
+        # For yearly_mmap_dense: resolve requested nodes → stored-index column index once
+        # at init (files are (n_days, n_zctas)).
+        self._node_store_idx = None
+        self._identity_rows = False
+        if file_format == "yearly_mmap_dense":
+            idx2zcta = load_idx2zcta(self.root_dir)
+            zcta2idx = {z: i for i, z in enumerate(idx2zcta)}
+            node_idx = np.array([zcta2idx.get(z, -1) for z in nodes], dtype=np.int64)
+            if (node_idx < 0).any():
+                missing = int((node_idx < 0).sum())
+                raise ValueError(
+                    f"{missing} of {len(nodes)} requested nodes not in idx2zcta.txt at {self.root_dir}"
+                )
+            self._node_store_idx = node_idx
+            # Fast path: requested nodes == stored idx2zcta order -> skip gather.
+            self._identity_rows = (
+                len(node_idx) == len(idx2zcta)
+                and bool(np.array_equal(node_idx, np.arange(len(idx2zcta))))
+            )
 
     def __len__(self):
         return len(self.lead_dates)
 
     def __getitem__(self, idx):
-        # Get the date range for the window
-        # end_dates[idx] corresponds to yyyymmdd[idx + window - 1]
-        dates = self.yyyymmdd[idx:idx + self.window]  # Get the last 'window' dates
-        
-        # Initialize tensor for this variable across the window
+        if self.file_format == "daily_parquet":
+            tensor = self._getitem_parquet(idx)
+        else:
+            tensor = self._getitem_mmap(idx)
+
+        if self.transform:
+            tensor = self.transform(tensor)
+
+        return tensor
+
+    # ----- daily_parquet path: original main behaviour, with /{file_format}/ subdir -----
+
+    def _getitem_parquet(self, idx):
+        dates = self.yyyymmdd[idx:idx + self.window]
         tensor = torch.full((len(self.nodes), len(self.vars), self.window), fill_value=torch.nan, dtype=torch.float32)
 
         for var_group_name, var_group in self.var_dict.items():
             temporal_res = var_group["temporal_res"]
-            
+
             for var in var_group["vars"]:
-                # Get the index for the variable
                 var_index = self.var_to_idx[f"{var_group_name}_{var}"]
 
                 for date_idx, date_str in enumerate(dates):
-                    # Adjust date string based on temporal resolution
                     if temporal_res == "yearly":
                         file_date_str = date_str[:4]
                     elif temporal_res == "monthly":
                         file_date_str = date_str[:6]
                     else:  # daily
                         file_date_str = date_str
-                    
-                    filename = f"{self.root_dir}/{var_group_name}/{var}/{var}__{file_date_str}.parquet"
-            
-                    # # Read the parquet file
+
+                    filename = f"{self.root_dir}/{var_group_name}/{var}/{self.file_format}/{var}__{file_date_str}.parquet"
+
                     if var_group_name not in self.row_to_zcta_assignments:
                         if not os.path.exists(filename):
                             logging.warning(f"File {filename} does not exist. Filling with NaNs.")
@@ -90,7 +126,6 @@ class XDataset(Dataset):
 
                         table = pq.read_table(filename, columns=["zcta"]).to_pandas()
                         table["zcta_index"] = table["zcta"].apply(lambda z: self.node_to_idx.get(z, -1))
-                        # Filter out rows where zcta is not in node_to_idx
                         row_filter = (table["zcta_index"] != -1).values
                         zcta_index = torch.tensor(table["zcta_index"][row_filter].values, dtype=torch.long)
                         self.row_to_zcta_assignments[var_group_name] = (zcta_index, row_filter)
@@ -102,19 +137,69 @@ class XDataset(Dataset):
                     else:
                         logging.warning(f"File {filename} does not exist. Filling with NaNs.")
                         table = pd.DataFrame(columns=[var])
-                        
+
                     if not table.empty:
                         values = torch.tensor(table[var][row_filter].values, dtype=torch.float32)
-                        # apply normalization if stats available
                         mean, std = get_var_summy(self.summary_stats, var_group_name, var)
                         mask = ~torch.isnan(values)
                         values[mask] = (values[mask] - mean) / std
                         tensor[zcta_index, var_index, date_idx] = values
 
-        if self.transform:
-            tensor = self.transform(tensor)
-
         return tensor
+
+    # ----- yearly_mmap_dense path -----
+
+    def _year_chunks(self, idx, span):
+        days = self.yyyymmdd[idx:idx + span]
+        cursor = 0
+        while cursor < len(days):
+            day0 = days[cursor]
+            year = int(day0[:4])
+            year_days = _days_in_year(year)
+            doy0 = (
+                date(int(day0[:4]), int(day0[4:6]), int(day0[6:8]))
+                - date(year, 1, 1)
+            ).days
+            length = min(year_days - doy0, len(days) - cursor)
+            yield year, cursor, doy0, length
+            cursor += length
+
+    def _getitem_mmap(self, idx):
+        out = np.full((len(self.nodes), len(self.vars), self.window), np.nan, dtype=np.float32)
+        node_idx = self._node_store_idx
+
+        for var_group_name, var_group in self.var_dict.items():
+            temporal_res = var_group["temporal_res"]
+            for var in var_group["vars"]:
+                var_index = self.var_to_idx[f"{var_group_name}_{var}"]
+                mean, std = get_var_summy(self.summary_stats, var_group_name, var)
+
+                for year, dst, doy0, length in self._year_chunks(idx, self.window):
+                    path = f"{self.root_dir}/{var_group_name}/{var}/{self.file_format}/{var}__{year}.npy"
+                    if not os.path.exists(path):
+                        continue
+                    mm = np.load(path, mmap_mode="r")
+                    if temporal_res == "yearly":
+                        # mm shape: (n_zctas,). Broadcast the single value across `length` days.
+                        vec = mm if self._identity_rows else mm[node_idx]
+                        chunk = np.asarray(vec).astype(np.float32, copy=False)
+                        if std != 1 or mean != 0:
+                            chunk = (chunk - mean) / std
+                        out[:, var_index, dst:dst + length] = chunk[:, None]
+                    elif temporal_res == "daily":
+                        # file is (n_days, n_zctas): day-window is a contiguous row-slice.
+                        slc = np.ascontiguousarray(mm[doy0:doy0 + length, :])  # (length, n_zctas)
+                        sel = slc if self._identity_rows else slc[:, node_idx]
+                        chunk = sel.T.astype(np.float32, copy=False)           # (n_nodes, length)
+                        if std != 1 or mean != 0:
+                            chunk = (chunk - mean) / std
+                        out[:, var_index, dst:dst + length] = chunk
+                    else:
+                        raise ValueError(f"unsupported temporal_res {temporal_res!r} for yearly_mmap_dense")
+
+        return torch.from_numpy(out)
+
+
 
 
 @hydra.main(config_path="../conf/dataloader", config_name="config", version_base=None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy
 torch
 pandas>2.2.2
 pyarrow
-duckdb==0.9.2
+duckdb>=1.1
 hydra-core==1.3.2
 snakemake==8.16
 tqdm

--- a/snakefile.smk
+++ b/snakefile.smk
@@ -10,6 +10,9 @@ import math
 configfile: "conf/snakemake.yaml"
 min_year = config["min_year"]
 max_year = config["max_year"]
+fmt = config["format"]
+assert fmt in ("daily_parquet", "yearly_mmap_dense"), f"unsupported format {fmt!r} for covariates"
+ext = "parquet" if fmt == "daily_parquet" else "npy"
 
 output_file_lst = []
 var_map = {}
@@ -34,42 +37,74 @@ for vg in config["var_groups"]:
 
         date_range = pd.date_range(f"{min_year_curr}-01-01", f"{max_year_curr}-12-31", freq="D")
 
-        if var_map[vg]["temporal_res"] == "daily":
+        if fmt == "yearly_mmap_dense":
+            # one per-(var, year) cell regardless of temporal_res
+            var_map[vg]["date_range"] = list(range(min_year_curr, max_year_curr + 1))
+            output_file_lst += expand(
+                f"data/output/{{var_group}}/{{var}}/{fmt}/{{var}}__{{year}}.{ext}",
+                var_group=vg,
+                var=[v for v in vg_cfg["vars"]],
+                year=var_map[vg]["date_range"],
+            )
+        elif var_map[vg]["temporal_res"] == "daily":
             var_map[vg]["date_range"] = [(d.year, d.month, d.day) for d in date_range]
-            if config["max_days"]: 
+            if config["max_days"]:
                 var_map[vg]["date_range"] = var_map[vg]["date_range"][:int(config["max_days"])]
             # iterate through valid y/m/d combos, expand vars within each
             for y,m,d in var_map[vg]["date_range"]:
-                output_file_lst += expand("data/output/{var_group}/{var}/{var}__{year}{month:02d}{day:02d}.parquet",
-                                            var_group=vg,
-                                            var=[v for v in vg_cfg["vars"]],
-                                            year=y,
-                                            month=m,
-                                            day=d)
+                output_file_lst += expand(
+                    f"data/output/{{var_group}}/{{var}}/{fmt}/{{var}}__{{year}}{{month:02d}}{{day:02d}}.{ext}",
+                    var_group=vg,
+                    var=[v for v in vg_cfg["vars"]],
+                    year=y,
+                    month=m,
+                    day=d,
+                )
         elif var_map[vg]["temporal_res"] == "monthly":
             var_map[vg]["date_range"] = [(y, m) for y in range(min_year_curr, max_year_curr + 1) for m in range(1, 13)]
-            output_file_lst += expand("data/output/{var_group}/{var}/{var}__{year}{month:02d}.parquet",
-                            var_group=vg,
-                            var=[v for v in vg_cfg["vars"]],
-                            year=[y for y, m in var_map[vg]["date_range"]],
-                            month=[m for y, m in var_map[vg]["date_range"]])
-        else:
-            var_map[vg]["date_range"] = [y for y in range(min_year_curr, max_year_curr + 1)]
-            output_file_lst += expand("data/output/{var_group}/{var}/{var}__{year}.parquet",
+            output_file_lst += expand(
+                f"data/output/{{var_group}}/{{var}}/{fmt}/{{var}}__{{year}}{{month:02d}}.{ext}",
                 var_group=vg,
                 var=[v for v in vg_cfg["vars"]],
-                year=[y for y in var_map[vg]["date_range"]])
+                year=[y for y, m in var_map[vg]["date_range"]],
+                month=[m for y, m in var_map[vg]["date_range"]],
+            )
+        else:
+            var_map[vg]["date_range"] = [y for y in range(min_year_curr, max_year_curr + 1)]
+            output_file_lst += expand(
+                f"data/output/{{var_group}}/{{var}}/{fmt}/{{var}}__{{year}}.{ext}",
+                var_group=vg,
+                var=[v for v in vg_cfg["vars"]],
+                year=[y for y in var_map[vg]["date_range"]],
+            )
         f.close()
+
+# yearly_mmap_dense needs idx2zcta.txt at the output root.
+idx2zcta_dep = []
+if fmt == "yearly_mmap_dense":
+    output_file_lst.append("data/output/idx2zcta.txt")
+    # Build idx2zcta.txt ONCE before the parallel per-(var,year) jobs read it,
+    # else the workers race to create it and some read a half-written file.
+    idx2zcta_dep = ["data/output/idx2zcta.txt"]
 
 # Expand over all valid combinations of variable groups, variables, and dates
 rule all:
     input:
         output_file_lst
 
+rule idx2zcta:
+    output:
+        "data/output/idx2zcta.txt"
+    shell:
+        "python src/preprocessing.py target=idx2zcta "
+        f"format={fmt} hydra.run.dir=."
+
 # have excluded input entry for now
 rule preprocess:
+    input:
+        idx2zcta_dep
     output:
-        "data/output/{var_group}/{var}/{var}__{timestring}.parquet"
+        f"data/output/{{var_group}}/{{var}}/{fmt}/{{var}}__{{timestring}}.{ext}"
     params:
         script="src/preprocessing.py"
     run:
@@ -80,4 +115,5 @@ rule preprocess:
               f"var={wildcards.var} "
               f"spatial_res={spatial_res} "
               f"temporal_res={temporal_res} "
-              f"timestr={timestring}")
+              f"timestr={timestring} "
+              f"format={fmt}")

--- a/snakefile_health.smk
+++ b/snakefile_health.smk
@@ -7,6 +7,9 @@ configfile: "conf/health/snakemake.yaml"
 # Get config values
 years = config["years"]
 vars = config["vars"]
+fmt = config["format"]
+assert fmt in ("daily_parquet", "yearly_mmap_dense", "yearly_mmap_sparse"), \
+    f"unsupported format {fmt!r}"
 
 # Get paths
 if config["use_synthetic"]:
@@ -15,46 +18,87 @@ else:
     lego_dir = config["lego_dir"]
 
 
-print(f"Using dir:\n  - lego_dir: {lego_dir}\n")
+print(f"Using dir:\n  - lego_dir: {lego_dir}\n  - format: {fmt}\n")
 
-# Rule: final output is one sentinel file per ICD/year (Dec 31)
+if fmt == "daily_parquet":
+    var_year_pattern = "data/health/ccw/{var}/daily_parquet/{var}__{year}1231.parquet"
+    denom_pattern = "data/health/denom/daily_parquet/denom__{year}.parquet"
+elif fmt == "yearly_mmap_dense":
+    var_year_pattern = "data/health/ccw/{var}/yearly_mmap_dense/{var}__{year}.npy"
+    denom_pattern = "data/health/denom/yearly_mmap_dense/denom__{year}.npy"
+else:  # yearly_mmap_sparse
+    var_year_pattern = "data/health/ccw/{var}/yearly_mmap_sparse/{var}__{year}.npz"
+    denom_pattern = "data/health/denom/yearly_mmap_dense/denom__{year}.npy"  # denom always dense
+
+extra_inputs = []
+if fmt != "daily_parquet":
+    extra_inputs.append("data/health/idx2zcta.txt")
+
+# mmap formats read idx2zcta.txt at run time; make it an explicit prerequisite so
+# Snakemake builds it ONCE before the parallel per-(var,year) jobs (otherwise the
+# workers race to create it and some read a half-written file -> wrong n_zctas).
+idx2zcta_dep = ["data/health/idx2zcta.txt"] if fmt != "daily_parquet" else []
+
+# Rule: final output is one sentinel file per var/year
 rule all:
     input:
-        expand(
-            f"data/health/ccw/{{var}}/{{var}}__{{year}}1231.parquet",
-            var=vars,
-            year=years
-        ),
-        expand(
-            f"data/health/denom/denom__{{year}}.parquet",
-            year=years
-        )
+        expand(var_year_pattern, var=vars, year=years),
+        expand(denom_pattern, year=years),
+        extra_inputs
+
+rule idx2zcta:
+    output:
+        "data/health/idx2zcta.txt"
+    shell:
+        "python src/preprocessing_health.py target=idx2zcta "
+        f"lego_dir={lego_dir} format={fmt} hydra.run.dir=."
 
 # Rule: preprocess all data for given var and year
-rule preprocess_health:
-    output:
-        f"data/health/ccw/{{var}}/{{var}}__{{year}}1231.parquet"
-    params:
-        #horizons = config["horizons"],
-        lego_dir = lego_dir,
-    shell:
-        """
-        python src/preprocessing_health.py \
-            hydra.run.dir=. \
-            var={wildcards.var} \
-            year={wildcards.year} \
-            lego_dir={params.lego_dir} \
-        """
+if fmt == "daily_parquet":
+    rule preprocess_health:
+        output:
+            "data/health/ccw/{var}/daily_parquet/{var}__{year}1231.parquet"
+        params:
+            lego_dir = lego_dir,
+        shell:
+            """
+            python src/preprocessing_health.py \
+                hydra.run.dir=. \
+                var={wildcards.var} \
+                year={wildcards.year} \
+                lego_dir={params.lego_dir} \
+                format=daily_parquet
+            """
+else:
+    rule preprocess_health:
+        input:
+            idx2zcta_dep
+        output:
+            var_year_pattern
+        params:
+            lego_dir = lego_dir,
+        shell:
+            f"""
+            python src/preprocessing_health.py \
+                hydra.run.dir=. \
+                var={{wildcards.var}} \
+                year={{wildcards.year}} \
+                lego_dir={{params.lego_dir}} \
+                format={fmt}
+            """
 
 rule preprocess_denom:
+    input:
+        idx2zcta_dep
     output:
-        f"data/health/denom/denom__{{year}}.parquet"
+        denom_pattern
     params:
-        lego_dir = lego_dir
+        lego_dir = lego_dir,
     shell:
-        """
+        f"""
         python src/preprocessing_denom.py \
             hydra.run.dir=. \
-            year={wildcards.year} \
-            lego_dir={params.lego_dir} \
+            year={{wildcards.year}} \
+            lego_dir={{params.lego_dir}} \
+            format={fmt}
         """

--- a/src/preprocessing.py
+++ b/src/preprocessing.py
@@ -1,13 +1,47 @@
+import calendar
+import os
+
 import duckdb
 import hydra
-import os
+import numpy as np
 import pandas as pd
 
 
 @hydra.main(config_path="../conf", config_name="conf", version_base=None)
 def main(cfg):
+    target = cfg.get("target", "var_year")
+    fmt = cfg.get("format", "daily_parquet")
+
+    if target == "idx2zcta":
+        _write_idx2zcta(cfg)
+        return
+
+    if fmt == "daily_parquet":
+        _build_daily_parquet(cfg)
+    elif fmt == "yearly_mmap_dense":
+        _build_yearly_mmap_dense(cfg)
+    else:
+        raise ValueError(f"unsupported format {fmt!r} for covariates")
+
+
+def _source_col(cfg):
+    """Source column name in the lego view for the requested var.
+
+    Defaults to the var itself. A var_group may declare a ``lego_col`` template
+    when the lego column name differs from the canonical var name — e.g.
+    climate_types stores per-zone fractions as ``pct_af`` while the canonical
+    var (and downstream embedding key) is ``Af``. The template may reference
+    ``{var}`` and ``{var_lower}``.
+    """
+    tmpl = cfg.var_group.get("lego_col", None)
+    if tmpl:
+        return tmpl.format(var=cfg.var, var_lower=cfg.var.lower())
+    return cfg.var
+
+
+def _build_daily_parquet(cfg):
     # parsing timestring
-    month,day = None, None
+    month, day = None, None
     timestr = str(cfg.timestr)
     year = timestr[:4]
     if cfg.temporal_res == "yearly":
@@ -18,7 +52,7 @@ def main(cfg):
         month = timestr[4:6]
         time_col = "year, month"
         time_query = f"""SELECT {cfg.spatial_res}, '{year}', '{month}' AS year, month"""
-        match_query = f"""ON (i.{cfg.spatial_res} = d.{cfg.spatial_res} AND 
+        match_query = f"""ON (i.{cfg.spatial_res} = d.{cfg.spatial_res} AND
                               i.year = d.year AND
                               i.month = d.month)"""
     elif cfg.temporal_res == "daily":
@@ -28,12 +62,10 @@ def main(cfg):
         time_query = f"""SELECT {cfg.spatial_res}, DATE '{year}-{month}-{day}' AS date"""
         match_query = f"""ON (i.{cfg.spatial_res} = d.{cfg.spatial_res} AND i.date = d.date)"""
 
-    # getting input filepath
     cfg_vg = cfg.var_group
     input_fname = f"{cfg.input_dir}/{cfg_vg.lego_dir}/{cfg_vg.lego_nm}__{year}.parquet"
 
-    # setting output filepath
-    out_dir = f"{cfg.output_dir}/{cfg.vg_name}/{cfg.var}/"
+    out_dir = f"{cfg.output_dir}/{cfg.vg_name}/{cfg.var}/{cfg.format}/"
     os.makedirs(out_dir, exist_ok=True)
 
     output_fname = f"{out_dir}/{cfg.var}__{year}"
@@ -43,24 +75,23 @@ def main(cfg):
         output_fname += str(day).zfill(2)
     output_fname += ".parquet"
 
-    # getting unique id list
     uniq_path = f"{cfg.input_dir}/{cfg.uniqid_dir}/{cfg.uniqid_nm}/{cfg.spatial_res}_yearly/{cfg.uniqid_nm}__{cfg.spatial_res}_yearly__{year}.parquet"
 
     duckdb.execute(f"""
-        CREATE TABLE index AS 
+        CREATE TABLE index AS
         {time_query}
-        FROM read_parquet('{uniq_path}') 
+        FROM read_parquet('{uniq_path}')
         WHERE continental_us = TRUE
         ORDER BY {cfg.spatial_res}
     """)
 
-    # Optimized query: Apply filtering *before* joining
+    src_col = _source_col(cfg)
     query = f"""
         COPY (
             SELECT i.{cfg.spatial_res}, d.{cfg.var}
             FROM index AS i
             LEFT JOIN (
-                SELECT {cfg.spatial_res}, {time_col}, {cfg.var} FROM read_parquet('{input_fname}')
+                SELECT {cfg.spatial_res}, {time_col}, {src_col} AS {cfg.var} FROM read_parquet('{input_fname}')
             ) AS d
             {match_query}
         ) TO '{output_fname}' (FORMAT 'parquet');
@@ -68,6 +99,96 @@ def main(cfg):
 
     duckdb.execute(query)
 
-    
+
+def _build_yearly_mmap_dense(cfg):
+    """Build the per-(var, year) dense .npy in idx2zcta (row index -> zcta) order.
+
+    Reads the same lego-raw year file as ``_build_daily_parquet`` (a sibling
+    format, not a transform of the daily_parquet output) and scatters the
+    values into a (n_periods, n_zctas) array. The ZCTA axis is the
+    LAST axis so a contiguous time-window slice (the loader's access pattern)
+    is a fast row-slice rather than a strided column-slice. ZCTAs absent from
+    a year stay NaN (same semantics as the daily LEFT JOIN). Yearly vars have
+    no time axis and stay 1-D (n_zctas,).
+    """
+    year = int(str(cfg.timestr)[:4])
+    cfg_vg = cfg.var_group
+    input_fname = f"{cfg.input_dir}/{cfg_vg.lego_dir}/{cfg_vg.lego_nm}__{year}.parquet"
+
+    out_dir = f"{cfg.output_dir}/{cfg.vg_name}/{cfg.var}/{cfg.format}/"
+    os.makedirs(out_dir, exist_ok=True)
+    output_fname = f"{out_dir}/{cfg.var}__{year}.npy"
+
+    idx2zcta = _ensure_idx2zcta(cfg)
+    n = len(idx2zcta)
+    z2i = {z: i for i, z in enumerate(idx2zcta)}
+    src_col = _source_col(cfg)
+
+    if cfg.temporal_res == "yearly":
+        df = duckdb.execute(f"""
+            SELECT {cfg.spatial_res} AS zcta, {src_col} AS val
+            FROM read_parquet('{input_fname}')
+            WHERE year = {year}
+        """).df()
+        arr = np.full((n,), np.nan, dtype=np.float32)
+        rows = df["zcta"].map(z2i).to_numpy()
+        keep = ~pd.isna(rows)
+        arr[rows[keep].astype(np.int64)] = df.loc[keep, "val"].to_numpy().astype(np.float32, copy=False)
+    elif cfg.temporal_res == "monthly":
+        df = duckdb.execute(f"""
+            SELECT {cfg.spatial_res} AS zcta, month, {src_col} AS val
+            FROM read_parquet('{input_fname}')
+            WHERE year = {year}
+        """).df()
+        # (n_months, n_zctas): time axis first so a month-window is a row-slice.
+        arr = np.full((12, n), np.nan, dtype=np.float32)
+        rows = df["zcta"].map(z2i).to_numpy()
+        keep = ~pd.isna(rows)
+        cols = df.loc[keep, "month"].to_numpy().astype(np.int64) - 1
+        arr[cols, rows[keep].astype(np.int64)] = df.loc[keep, "val"].to_numpy().astype(np.float32, copy=False)
+    elif cfg.temporal_res == "daily":
+        n_days = 366 if calendar.isleap(year) else 365
+        df = duckdb.execute(f"""
+            SELECT {cfg.spatial_res} AS zcta, date, {src_col} AS val
+            FROM read_parquet('{input_fname}')
+            WHERE date >= DATE '{year}-01-01' AND date <= DATE '{year}-12-31'
+        """).df()
+        # (n_days, n_zctas): time axis first so a day-window is a row-slice.
+        arr = np.full((n_days, n), np.nan, dtype=np.float32)
+        rows = df["zcta"].map(z2i).to_numpy()
+        keep = ~pd.isna(rows)
+        doys = (pd.to_datetime(df.loc[keep, "date"]) - pd.Timestamp(year=year, month=1, day=1)).dt.days.to_numpy()
+        arr[doys, rows[keep].astype(np.int64)] = df.loc[keep, "val"].to_numpy().astype(np.float32, copy=False)
+    else:
+        raise ValueError(f"unsupported temporal_res {cfg.temporal_res!r}")
+
+    np.save(output_fname, arr)
+
+
+def _ensure_idx2zcta(cfg):
+    """Return the idx2zcta list; write idx2zcta.txt at output_dir if absent."""
+    idx2zcta_path = f"{cfg.output_dir}/idx2zcta.txt"
+    if os.path.exists(idx2zcta_path):
+        with open(idx2zcta_path) as f:
+            return [line.strip() for line in f if line.strip()]
+    return _write_idx2zcta(cfg)
+
+
+def _write_idx2zcta(cfg):
+    """Derive the idx2zcta list from the lego unique-id parquets and write it once."""
+    uniq_glob = f"{cfg.input_dir}/{cfg.uniqid_dir}/{cfg.uniqid_nm}/{cfg.spatial_res}_yearly/{cfg.uniqid_nm}__{cfg.spatial_res}_yearly__*.parquet"
+    idx2zcta = duckdb.execute(f"""
+        SELECT DISTINCT {cfg.spatial_res}
+        FROM read_parquet('{uniq_glob}')
+        WHERE continental_us = TRUE
+        ORDER BY {cfg.spatial_res}
+    """).df()[cfg.spatial_res].tolist()
+    idx2zcta_path = f"{cfg.output_dir}/idx2zcta.txt"
+    os.makedirs(os.path.dirname(idx2zcta_path), exist_ok=True)
+    with open(idx2zcta_path, "w") as f:
+        f.write("\n".join(idx2zcta) + "\n")
+    return idx2zcta
+
+
 if __name__ == "__main__":
     main()

--- a/src/preprocessing_denom.py
+++ b/src/preprocessing_denom.py
@@ -1,7 +1,10 @@
 import os
-import hydra
 import logging
+
 import duckdb
+import hydra
+import numpy as np
+import pandas as pd
 import pyarrow.parquet as pq
 
 
@@ -12,35 +15,58 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 
+
 @hydra.main(config_path="../conf/health", config_name="config", version_base=None)
 def main(cfg):
-    """
-    Preprocess denominator data for health datasets.
-    """ 
-    
+    """Preprocess denominator data for health datasets."""
+    fmt = cfg.get("format", "daily_parquet")
     year = str(cfg.year)
     denom_path = f"{cfg.input_dir}/{cfg.lego_dir}/mbsf_medpar_denom/{cfg.min_spatial_res}_yearly/counts_{year}.parquet"
 
     LOGGER.info(f"Reading denominator data from {denom_path}")
-    
-    # make duckdb query counting rows grouping by zcta where age_dob in between 65 and 110
-    # denom_df = duckdb.sql(
-    #     f"""
-    #     SELECT zcta, COUNT(*) as count
-    #     FROM read_parquet('{denom_path}')
-    #     WHERE age_dob BETWEEN 65 AND 110
-    #     GROUP BY zcta
-    #     """
-    # Alternative implementation using DuckDB SQL is available in version control if needed.
     denom_df = pq.read_table(denom_path, columns=['zcta', 'n_bene']).to_pandas()
-    
-    # save table
-    tgt_file = f"{cfg.output_dir}/denom/denom__{year}.parquet"
-    os.makedirs(f"{cfg.output_dir}/denom/", exist_ok=True)
-    LOGGER.info(f"Saving processed denominator data to {tgt_file}")
-    denom_df.to_parquet(tgt_file)
 
-    LOGGER.info(f"Saved processed denominator data to {tgt_file}")
+    out_root = f"{cfg.output_dir}/denom/{fmt}"
+    os.makedirs(out_root, exist_ok=True)
+
+    if fmt == "daily_parquet":
+        tgt_file = f"{out_root}/denom__{year}.parquet"
+        LOGGER.info(f"Saving processed denominator data to {tgt_file}")
+        denom_df.to_parquet(tgt_file)
+    else:
+        # yearly_mmap_dense: int32 vector in idx2zcta (row index -> zcta) order, sentinel -1 for missing.
+        idx2zcta = _ensure_idx2zcta(cfg)
+        z2i = {z: i for i, z in enumerate(idx2zcta)}
+        arr = np.full((len(idx2zcta),), -1, dtype=np.int32)
+        rows = denom_df["zcta"].map(z2i).to_numpy()
+        keep = ~pd.isna(rows)
+        arr[rows[keep].astype(np.int64)] = denom_df.loc[keep, "n_bene"].to_numpy().astype(np.int32, copy=False)
+        # For yearly_mmap_sparse the denom shares the dense root, so write to
+        # /yearly_mmap_dense/ regardless (HealthDataset reads it from there).
+        out_root_dense = f"{cfg.output_dir}/denom/yearly_mmap_dense"
+        os.makedirs(out_root_dense, exist_ok=True)
+        tgt_file = f"{out_root_dense}/denom__{year}.npy"
+        np.save(tgt_file, arr)
+        LOGGER.info(f"Saved processed denominator data to {tgt_file}")
+
+
+def _ensure_idx2zcta(cfg):
+    idx2zcta_path = f"{cfg.output_dir}/idx2zcta.txt"
+    if not os.path.exists(idx2zcta_path):
+        # Build it on demand using the same source as preprocessing_health.py.
+        denom_glob = f"{cfg.input_dir}/{cfg.lego_dir}/mbsf_medpar_denom/{cfg.min_spatial_res}_yearly/counts_*.parquet"
+        idx2zcta = duckdb.execute(f"""
+            SELECT DISTINCT zcta
+            FROM read_parquet('{denom_glob}')
+            ORDER BY zcta
+        """).df()["zcta"].tolist()
+        os.makedirs(os.path.dirname(idx2zcta_path), exist_ok=True)
+        with open(idx2zcta_path, "w") as f:
+            f.write("\n".join(idx2zcta) + "\n")
+        LOGGER.info(f"Wrote {idx2zcta_path} ({len(idx2zcta)} zctas)")
+        return idx2zcta
+    with open(idx2zcta_path) as f:
+        return [line.strip() for line in f if line.strip()]
 
 
 if __name__ == "__main__":

--- a/src/preprocessing_health.py
+++ b/src/preprocessing_health.py
@@ -1,9 +1,12 @@
-from datetime import date, timedelta
+import calendar
+import logging
+import os
+
 import duckdb
 import hydra
-import os
-import logging
-import calendar
+import numpy as np
+import pandas as pd
+import scipy.sparse
 from tqdm import tqdm
 
 
@@ -14,81 +17,130 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 
+
 @hydra.main(config_path="../conf/health", config_name="config", version_base=None)
 def main(cfg):
     """
     Preprocess health data for data loader.
     Current implementation is for the LEGO dataset.
-    Only zcta daily data is supported (with hardcoded vars)
+    Only zcta daily data is supported (with hardcoded vars).
     """
+    target = cfg.get("target", "var_year")
+    fmt = cfg.get("format", "daily_parquet")
 
-    conn = duckdb.connect()
+    if target == "idx2zcta":
+        _write_idx2zcta(cfg)
+        return
 
+    if fmt == "daily_parquet":
+        _build_daily_parquet(cfg)
+    elif fmt in ("yearly_mmap_dense", "yearly_mmap_sparse"):
+        _build_yearly_mmap(cfg, sparse=(fmt == "yearly_mmap_sparse"))
+    else:
+        raise ValueError(f"unsupported format {fmt!r}")
+
+
+def _build_daily_parquet(cfg):
     LOGGER.info(f"Processing data for {cfg.var}")
     resolution = f"{cfg.min_spatial_res}_{cfg.min_temporal_res}"
     input_files = f"{cfg.input_dir}/{cfg.lego_dir}/medpar_outcomes/{cfg.vg_name}/{resolution}/{cfg.lego_prefix}_*.parquet"
-    output_folder = f"{cfg.output_dir}/{cfg.vg_name}/{cfg.var}"
+    output_folder = f"{cfg.output_dir}/{cfg.vg_name}/{cfg.var}/{cfg.format}"
     os.makedirs(output_folder, exist_ok=True)
 
-    year = cfg.year
-    horizons = cfg.horizons
+    year = int(cfg.year)
     LOGGER.info(f"Processing year {year}")
 
-    # get days list for a given year with calendar days
+    # One query for the whole year, then split into per-day files in memory.
+    # Output is identical to a per-day query (one file per calendar day with
+    # columns (zcta, n) sorted by zcta; empty file on days with no counts) but
+    # avoids re-scanning the source once per day.
+    df = duckdb.execute(f"""
+        SELECT zcta, date, n
+        FROM '{input_files}'
+        WHERE var = '{cfg.var}' AND date >= DATE '{year}-01-01' AND date <= DATE '{year}-12-31'
+    """).df()
+    df["ds"] = pd.to_datetime(df["date"]).dt.strftime("%Y%m%d")
+    by_day = dict(tuple(df.groupby("ds")))
+    empty = df.iloc[0:0][["zcta", "n"]]
+
     days_list = [(year, month, day) for month in range(1, 13) for day in range(1, calendar.monthrange(year, month)[1] + 1)]
-    for day in tqdm(days_list, desc="Processing days"):
-        date_str = f"{day[0]}{day[1]:02d}{day[2]:02d}"
-        output_fname = f"{output_folder}/{cfg.var}__{date_str}.parquet"
-
-        t = date(day[0], day[1], day[2])
-
-        # Build queries for each horizon, starting with same-day (horizon = 0)
-        queries = []
-
-        # Same-day count (horizon = 0)
-        queries.append(f"""
-            SELECT 
-                zcta, 
-                0 AS horizon, 
-                n
-            FROM '{input_files}'
-            WHERE
-                var = '{cfg.var}' AND 
-                date = DATE '{t}'
-        """)
-
-        # Future horizons
-        for horizon in horizons:
-            t_end = t + timedelta(days=horizon)
-            queries.append(f"""
-                SELECT 
-                    zcta, 
-                    {horizon} AS horizon, 
-                    SUM(n) AS n
-                FROM '{input_files}'
-                WHERE 
-                    var = '{cfg.var}' AND 
-                    date >= DATE '{t}' AND 
-                    date <= DATE '{t_end}'
-                GROUP BY zcta
-            """)
-
-        # Combine all queries into one
-        full_query = " UNION ALL ".join(queries)
-
-        # Execute and save
-        conn.execute(f"""
-            CREATE OR REPLACE TABLE output AS
-            {full_query}
-        """)
-
-        conn.execute(f"""
-            COPY (SELECT * FROM output ORDER BY zcta, horizon) 
-            TO '{output_fname}'
-        """)
+    for (yy, mm, dd) in tqdm(days_list, desc="Processing days"):
+        date_str = f"{yy}{mm:02d}{dd:02d}"
+        sub = by_day.get(date_str)
+        out = sub[["zcta", "n"]].sort_values("zcta") if sub is not None else empty
+        out.to_parquet(f"{output_folder}/{cfg.var}__{date_str}.parquet", index=False)
 
 
-    conn.close()
-    
+def _build_yearly_mmap(cfg, sparse):
+    """Build (n_days_in_year, n_zctas) int16 count matrix for one (var, year).
+    Time axis first so a contiguous day-window is a fast row-slice (dense) / CSR
+    row-slice (sparse) rather than a strided column-slice. Same-day counts only."""
+    LOGGER.info(f"Building {cfg.format} for {cfg.var}/{cfg.year}")
+    resolution = f"{cfg.min_spatial_res}_{cfg.min_temporal_res}"
+    input_files = f"{cfg.input_dir}/{cfg.lego_dir}/medpar_outcomes/{cfg.vg_name}/{resolution}/{cfg.lego_prefix}_*.parquet"
+
+    output_folder = f"{cfg.output_dir}/{cfg.vg_name}/{cfg.var}/{cfg.format}"
+    os.makedirs(output_folder, exist_ok=True)
+    ext = "npz" if sparse else "npy"
+    output_fname = f"{output_folder}/{cfg.var}__{cfg.year}.{ext}"
+
+    idx2zcta = _ensure_idx2zcta(cfg)
+    n_zctas = len(idx2zcta)
+    year = int(cfg.year)
+    n_days = 366 if calendar.isleap(year) else 365
+
+    df = duckdb.execute(f"""
+        SELECT zcta, date, n
+        FROM '{input_files}'
+        WHERE
+            var = '{cfg.var}' AND
+            date >= DATE '{year}-01-01' AND
+            date <= DATE '{year}-12-31'
+    """).df()
+
+    z2i = {z: i for i, z in enumerate(idx2zcta)}
+    rows = df["zcta"].map(z2i).to_numpy()
+    keep = ~pd.isna(rows)
+    rows = rows[keep].astype(np.int64)
+    doys = (pd.to_datetime(df.loc[keep, "date"]) - pd.Timestamp(year=year, month=1, day=1)).dt.days.to_numpy()
+    vals = df.loc[keep, "n"].to_numpy()
+    if vals.size and vals.max() > 32_000:
+        raise OverflowError(f"{cfg.var}/{year}: max count {vals.max()} > 32 000; int16 would overflow")
+
+    arr = np.zeros((n_days, n_zctas), dtype=np.int16)
+    arr[doys, rows] = vals.astype(np.int16, copy=False)
+
+    if sparse:
+        # CSR with day as the major axis -> a day-window is a contiguous CSR row-slice.
+        scipy.sparse.save_npz(output_fname, scipy.sparse.csr_matrix(arr))
+    else:
+        np.save(output_fname, arr)
+    LOGGER.info(f"Saved {output_fname}")
+
+
+def _ensure_idx2zcta(cfg):
+    idx2zcta_path = f"{cfg.output_dir}/idx2zcta.txt"
+    if os.path.exists(idx2zcta_path):
+        with open(idx2zcta_path) as f:
+            return [line.strip() for line in f if line.strip()]
+    return _write_idx2zcta(cfg)
+
+
+def _write_idx2zcta(cfg):
+    """Derive the idx2zcta list from the medpar denom files and write it once."""
+    denom_glob = f"{cfg.input_dir}/{cfg.lego_dir}/mbsf_medpar_denom/{cfg.min_spatial_res}_yearly/counts_*.parquet"
+    idx2zcta = duckdb.execute(f"""
+        SELECT DISTINCT zcta
+        FROM read_parquet('{denom_glob}')
+        ORDER BY zcta
+    """).df()["zcta"].tolist()
+    idx2zcta_path = f"{cfg.output_dir}/idx2zcta.txt"
+    os.makedirs(os.path.dirname(idx2zcta_path), exist_ok=True)
+    with open(idx2zcta_path, "w") as f:
+        f.write("\n".join(idx2zcta) + "\n")
+    LOGGER.info(f"Wrote {idx2zcta_path} ({len(idx2zcta)} zctas)")
+    return idx2zcta
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Adds a `file_format` kwarg to the datasets and preprocessing:
  - daily_parquet      (baseline per-(var,day) layout, in a /{fmt}/ subdir)
  - yearly_mmap_dense  (default; one .npy memmap per (var, year))
  - yearly_mmap_sparse (CSR per (var, year); outcomes only)
__init__ opens nothing; __getitem__ does one column-slice + row-gather per
(var, year). mmaps are built from RAW lego, in canonical ZCTA order.

Removes horizon functionality entirely: health daily_parquet stores the raw same-day (zcta, n) only — no horizon column, no 30/90/180 forward sums — and the loader no longer filters horizon (delta_t-only scope).

Fixes:
  - duckdb .df()/.fetchnumpy() raise "resize only works on single-segment arrays" under numpy 2 and silently corrupted mmaps (census income / home_value all-NaN in 2010/2020). Route extractions through .arrow().to_pandas().
  - gridmet/aqdh var_group sources repointed to existing raw lego views.