### PR TITLE
sliding window width in loader

### DIFF
--- a/legoloaderx/health_dataloader.py
+++ b/legoloaderx/health_dataloader.py
@@ -33,6 +33,7 @@ class HealthDataset(Dataset):
         min_year=2000,
         max_year=2020,
         min_bene=10,
+        sliding_window=1,
     ):
         assert delta_t is not None and delta_t >= 0, "delta_t must be a non-negative integer"
         self.root_dir = root_dir
@@ -47,7 +48,8 @@ class HealthDataset(Dataset):
 
         all_dates = pd.date_range(f"{min_year}-01-01", f"{max_year}-12-31", freq="D")
         self.yyyymmdd = [f"{d.year}{d.month:02d}{d.day:02d}" for d in all_dates]
-        self.lead_dates = self.yyyymmdd[window - 1:-delta_t] if delta_t > 0 else self.yyyymmdd[window - 1:]
+        dense = self.yyyymmdd[window - 1:-delta_t] if delta_t > 0 else self.yyyymmdd[window - 1:]
+        self.lead_dates = dense[::sliding_window]
 
         # Resolve requested nodes -> stored column index once, via the canonical order.
         idx2zcta = pd.read_parquet(f"{root_dir}/idx2zcta.parquet")["zcta"].tolist()

--- a/legoloaderx/health_x_dataloader.py
+++ b/legoloaderx/health_x_dataloader.py
@@ -26,6 +26,7 @@ class HealthXDataset(Dataset):
         summary_stats=None,
         min_year=2000,
         max_year=2020,
+        sliding_window=1,
     ):
         self.root_dir = root_dir
         self.var_dict = var_dict
@@ -42,6 +43,7 @@ class HealthXDataset(Dataset):
             delta_t=delta_t,
             min_year=min_year,
             max_year=max_year,
+            sliding_window=sliding_window,
         )
         self.delta_t = self.outcomes_dataset.delta_t
 


### PR DESCRIPTION
Fixes #54, means that a single epoch does not include `lead_dates` starting at every single date in the training dataset range (i.e. 12 years x 365 days = 4380 batches). Instead, `lead_dates` are every `sliding_window` days. Not a huge fan of this implementation, because every epoch would have the exact same lead dates (and exclude other lead dates by necessity), but wanted to make the PR to start the conversation